### PR TITLE
Vessel-144 unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         run: make check-lint
       - name: Check types
         run: make check-typecheck  
-     # - name: Execute unit tests
-     #   run: make test
+      - name: Execute unit tests
+        run: make test
 
   docker:
     runs-on: ubuntu-latest

--- a/test/util/test_oci.py
+++ b/test/util/test_oci.py
@@ -39,7 +39,7 @@ def create_test_manifest(manifest_path: Path, hash: str):
 
 
 def test_get_manifest_digest(tmp_path: Path):
-    """Tests tha parsing works for common sample transport strings."""
+    """Tests that a hash can be properly obtained from a manifest file."""
 
     test_hash = (
         "f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f"

--- a/test/util/test_oci.py
+++ b/test/util/test_oci.py
@@ -1,0 +1,53 @@
+# Vessel Diff Tool
+#
+# Copyright 2024 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING
+# INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON
+# UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+# AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS
+# FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM
+# USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY
+# WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK,
+# OR COPYRIGHT INFRINGEMENT.
+#
+# Licensed under a MIT (SEI)-style license, please see license.txt
+# or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public
+# release and unlimited distribution.  Please see Copyright notice
+# for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software
+# each subject to its own license.
+#
+# DM24-1321
+
+"""Unit tests for the oci module."""
+
+import json
+from pathlib import Path
+
+from vessel.utils.oci import get_manifest_digest
+
+
+def create_test_manifest(manifest_path: Path, hash: str):
+    """Creates a manifest in the given file, with the given hash."""
+    data = {"manifests": [{"digest": f"sha256:{hash}"}]}
+    with open(manifest_path, "w") as file:
+        json.dump(data, file, indent=4)
+
+
+def test_get_manifest_digest(tmp_path: Path):
+    """Tests tha parsing works for common sample transport strings."""
+
+    test_hash = (
+        "f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f"
+    )
+    manifest_file = "index.json"
+    manifest_path = tmp_path / manifest_file
+    create_test_manifest(manifest_path, test_hash)
+
+    digest = get_manifest_digest(str(tmp_path))
+
+    assert digest == test_hash

--- a/test/util/test_uri.py
+++ b/test/util/test_uri.py
@@ -27,29 +27,38 @@
 
 import pytest
 
-from vessel.utils.uri import parse_container_transport
+from vessel.utils.uri import ImageURI, parse_container_transport
+
+TEST_TRANSPORT_STRINGS = [
+    ("docker://user/image", ("image", "latest")),
+    ("docker://user/image:1.0", ("image", "1.0")),
+    ("docker://image", ("image", "latest")),
+    ("docker://image:1.0", ("image", "1.0")),
+    ("docker-daemon:user/image", ("image", "latest")),
+    ("docker-daemon:user/image:1.0", ("image", "1.0")),
+    ("docker-archive:user/image", ("image", "latest")),
+    ("docker-archive:user/image:1.0", ("image", "1.0")),
+    ("oci:/users/images/image", ("image", "latest")),
+    ("oci:/users/images/image:1.0", ("image", "1.0")),
+    ("oci-archive:/users/images/image.tar", ("image.tar", "latest")),
+    ("oci-archive:/users/images/image.tar:1.0", ("image.tar", "1.0")),
+]
 
 
-@pytest.mark.parametrize(
-    "test_input, expected",
-    [
-        ("docker://user/image", ("image, latest")),
-        ("docker://user/image:1.0", ("image, 1.0")),
-        ("docker://image", ("image, latest")),
-        ("docker://image:1.0", ("image, 1.0")),
-        ("docker-daemon:user/image", ("image, latest")),
-        ("docker-daemon:user/image:1.0", ("image, 1.0")),
-        ("docker-archive:user/image", ("image, latest")),
-        ("docker-archive:user/image:1.0", ("image, 1.0")),
-        ("oci:/users/images/image", ("image, latest")),
-        ("oci:/users/images/image:1.0", ("image, 1.0")),
-        ("oci-archive:/users/images/image.tar", ("image.tar, latest")),
-        ("oci-archive:/users/images/image.tar:1.0", ("image.tar, 1.0")),
-    ],
-)
+@pytest.mark.parametrize("test_input, expected", TEST_TRANSPORT_STRINGS)
 def test_parse_container_transport(test_input: str, expected: tuple[str, str]):
     """Tests tha parsing works for common sample transport strings."""
 
     image_name, tag = parse_container_transport(test_input)
 
-    assert image_name, tag == expected
+    assert (image_name, tag) == expected
+
+
+@pytest.mark.parametrize("test_input, expected", TEST_TRANSPORT_STRINGS)
+def test_image_uri_constructor(test_input: str, expected: tuple[str, str]):
+    """Tests tha parsing works for common sample transport strings."""
+
+    uri = ImageURI(test_input)
+
+    assert (uri.image_name, uri.tag) == expected
+    assert uri.output_identifier == f"{expected[0]}.{expected[1]}"

--- a/test/util/test_uri.py
+++ b/test/util/test_uri.py
@@ -47,7 +47,7 @@ TEST_TRANSPORT_STRINGS = [
 
 @pytest.mark.parametrize("test_input, expected", TEST_TRANSPORT_STRINGS)
 def test_parse_container_transport(test_input: str, expected: tuple[str, str]):
-    """Tests tha parsing works for common sample transport strings."""
+    """Tests that parsing works for common sample transport strings."""
 
     image_name, tag = parse_container_transport(test_input)
 
@@ -56,7 +56,7 @@ def test_parse_container_transport(test_input: str, expected: tuple[str, str]):
 
 @pytest.mark.parametrize("test_input, expected", TEST_TRANSPORT_STRINGS)
 def test_image_uri_constructor(test_input: str, expected: tuple[str, str]):
-    """Tests tha parsing works for common sample transport strings."""
+    """Tests that creating an ImageURI object, which itself parses a transport string, sets up its attributes properly."""
 
     uri = ImageURI(test_input)
 

--- a/test/util/test_uri.py
+++ b/test/util/test_uri.py
@@ -1,0 +1,55 @@
+# Vessel Diff Tool
+#
+# Copyright 2024 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING
+# INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON
+# UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+# AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS
+# FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM
+# USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY
+# WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK,
+# OR COPYRIGHT INFRINGEMENT.
+#
+# Licensed under a MIT (SEI)-style license, please see license.txt
+# or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public
+# release and unlimited distribution.  Please see Copyright notice
+# for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software
+# each subject to its own license.
+#
+# DM24-1321
+
+"""Unit tests for the uri module."""
+
+import pytest
+
+from vessel.utils.uri import parse_container_transport
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        ("docker://user/image", ("image, latest")),
+        ("docker://user/image:1.0", ("image, 1.0")),
+        ("docker://image", ("image, latest")),
+        ("docker://image:1.0", ("image, 1.0")),
+        ("docker-daemon:user/image", ("image, latest")),
+        ("docker-daemon:user/image:1.0", ("image, 1.0")),
+        ("docker-archive:user/image", ("image, latest")),
+        ("docker-archive:user/image:1.0", ("image, 1.0")),
+        ("oci:/users/images/image", ("image, latest")),
+        ("oci:/users/images/image:1.0", ("image, 1.0")),
+        ("oci-archive:/users/images/image.tar", ("image.tar, latest")),
+        ("oci-archive:/users/images/image.tar:1.0", ("image.tar, 1.0")),
+    ],
+)
+def test_parse_container_transport(test_input: str, expected: tuple[str, str]):
+    """Tests tha parsing works for common sample transport strings."""
+
+    image_name, tag = parse_container_transport(test_input)
+
+    assert image_name, tag == expected


### PR DESCRIPTION
Addresses the creation of unit tests for the oci and uri modules. Also generally enables checking tests in GithubActions, since now we have our first tests.

NOTE: depends on PR #1 being merged first.