### PR TITLE
VESSEL-148

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -35,7 +35,7 @@ def get_test_flag():
         filetype=".",
         command=".",
         comment=".",
-        indiff=r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{9}",
+        indiff=r"\d+",
     )
 
 

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -40,7 +40,7 @@ from vessel.utils.unified_diff import (
 )
 
 # -----------------------------------------------------------------------------
-# Tests for Diff.to_dict()
+# Tests for Diff.to_dict
 # -----------------------------------------------------------------------------
 
 TEST_DIFF_CLASS_OBJECTS = [
@@ -74,41 +74,63 @@ def test_Diff_to_dict(test_input, expected):
 
 
 # -----------------------------------------------------------------------------
-# Tests for equal_entry_list()
+# Tests for DiffLine
+# -----------------------------------------------------------------------------
+
+TEST_DIFFLINE_DATA = [
+    (
+        {"text": "012345", "diff_line_number": 7, "file_line_number": 8},
+        {"text": "012345", "diff_line_number": 7, "file_line_number": 8}
+    )
+]
+
+@pytest.mark.parametrize("test_input, expected", TEST_DIFFLINE_DATA)
+def test_DiffLine(test_input, expected):
+    """Tests for DiffLine class."""
+
+    diffline = DiffLine(**test_input)
+
+    assert diffline.diff_line_number == expected["diff_line_number"]
+    assert diffline.file_line_number == expected["file_line_number"]
+    assert intervals_to_str(diffline.text, diffline.unmatched_intervals) == expected["text"]
+
+
+# -----------------------------------------------------------------------------
+# Tests for equal_entry_list
 # -----------------------------------------------------------------------------
 
 TEST_LISTS = [
     (
-        {"list1": [1, 2], "list2": [1, 2, 3], "fillValue": -1},
+        {"list1": [1, 2], "list2": [1, 2, 3], "fill_value": -1},
         {"list1": [1, 2, -1], "list2": [1, 2, 3]},
     ),
     (
-        {"list1": [1, 2], "list2": [1, 2, 3, 4, 5], "fillValue": -1},
+        {"list1": [1, 2], "list2": [1, 2, 3, 4, 5], "fill_value": -1},
         {"list1": [1, 2, -1, -1, -1], "list2": [1, 2, 3, 4, 5]},
     ),
     (
-        {"list1": [1, 2, 3], "list2": [1, 2], "fillValue": -1},
+        {"list1": [1, 2, 3], "list2": [1, 2], "fill_value": -1},
         {"list1": [1, 2, 3], "list2": [1, 2, -1]},
     ),
     (
-        {"list1": [1, 2, 3, 4, 5], "list2": [1, 2], "fillValue": -1},
+        {"list1": [1, 2, 3, 4, 5], "list2": [1, 2], "fill_value": -1},
         {"list1": [1, 2, 3, 4, 5], "list2": [1, 2, -1, -1, -1]},
     ),
-    ({"list1": [], "list2": [], "fillValue": -1}, {"list1": [], "list2": []}),
+    ({"list1": [], "list2": [], "fill_value": -1}, {"list1": [], "list2": []}),
     (
-        {"list1": [], "list2": [1], "fillValue": -1},
+        {"list1": [], "list2": [1], "fill_value": -1},
         {"list1": [-1], "list2": [1]},
     ),
     (
-        {"list1": [], "list2": [1, 2], "fillValue": -1},
+        {"list1": [], "list2": [1, 2], "fill_value": -1},
         {"list1": [-1, -1], "list2": [1, 2]},
     ),
     (
-        {"list1": [1], "list2": [], "fillValue": -1},
+        {"list1": [1], "list2": [], "fill_value": -1},
         {"list1": [1], "list2": [-1]},
     ),
     (
-        {"list1": [1, 2], "list2": [], "fillValue": -1},
+        {"list1": [1, 2], "list2": [], "fill_value": -1},
         {"list1": [1, 2], "list2": [-1, -1]},
     ),
 ]
@@ -118,16 +140,14 @@ TEST_LISTS = [
 def test_equal_entry_list(test_input: dict, expected: dict):
     """Tests that inputted lists are returned equal length with the correct fill value."""
 
-    equal_list1, equal_list2 = equal_entry_list(
-        test_input["list1"], test_input["list2"], test_input["fillValue"]
-    )
+    equal_list1, equal_list2 = equal_entry_list(**test_input)
 
     assert equal_list1 == expected["list1"]
     assert equal_list2 == expected["list2"]
 
 
 # -----------------------------------------------------------------------------
-# Tests for parse_unified_diff_header()
+# Tests for parse_unified_diff_header
 # -----------------------------------------------------------------------------
 
 TEST_UNIFIED_DIFF_HEADERS = [
@@ -147,7 +167,7 @@ def test_parse_unified_diff_header(test_input: str, expected: tuple[int, int]):
 
 
 # -----------------------------------------------------------------------------
-# Tests for align_diff_lines()
+# Tests for align_diff_lines
 # -----------------------------------------------------------------------------
 
 TEST_UNIFIED_DIFFS = [
@@ -392,7 +412,7 @@ def test_align_diff_lines(test_input, expected):
 
 
 # -----------------------------------------------------------------------------
-# Tests for issues_from_difflines()
+# Tests for issues_from_difflines
 # -----------------------------------------------------------------------------
 
 TEST_DIFFLINES = [
@@ -457,9 +477,7 @@ TEST_DIFFLINES = [
 def test_issues_from_difflines(test_input, expected):
     """Tests that issues are correctly flagged, and intervals are updated correctly"""
 
-    flagged, unknown, minus_unmatched, plus_unmatched = issues_from_difflines(
-        test_input["minus_line"], test_input["plus_line"], test_input["flag"]
-    )
+    flagged, unknown, minus_unmatched, plus_unmatched = issues_from_difflines(**test_input)
 
     assert flagged == expected["flagged"]
     assert unknown == expected["unknown"]
@@ -468,7 +486,7 @@ def test_issues_from_difflines(test_input, expected):
 
 
 # -----------------------------------------------------------------------------
-# Tests for make_issue_dict()
+# Tests for make_issue_dict
 # -----------------------------------------------------------------------------
 
 TEST_ISSUE_DICT_INPUT = [
@@ -532,25 +550,25 @@ def test_make_issue_dict(test_input, expected):
 
 
 # -----------------------------------------------------------------------------
-# Tests for intervals_to_str()
+# Tests for intervals_to_str
 # -----------------------------------------------------------------------------
 
 TEST_INTERVALS = [
-    ({"str": "0123456789", "interval": portion.closed(3, 6)}, "3456"),
-    ({"str": "0123456789", "interval": portion.open(3, 6)}, "45"),
-    ({"str": "0123456789", "interval": portion.openclosed(3, 6)}, "456"),
-    ({"str": "0123456789", "interval": portion.closedopen(3, 6)}, "345"),
+    ({"input_string": "0123456789", "intervals": portion.closed(3, 6)}, "3456"),
+    ({"input_string": "0123456789", "intervals": portion.open(3, 6)}, "45"),
+    ({"input_string": "0123456789", "intervals": portion.openclosed(3, 6)}, "456"),
+    ({"input_string": "0123456789", "intervals": portion.closedopen(3, 6)}, "345"),
     (
         {
-            "str": "0123456789",
-            "interval": portion.closed(1, 3) | portion.closed(5, 7),
+            "input_string": "0123456789",
+            "intervals": portion.closed(1, 3) | portion.closed(5, 7),
         },
         "123567",
     ),
     (
         {
-            "str": "0123456789",
-            "interval": portion.open(1, 3) | portion.open(5, 7),
+            "input_string": "0123456789",
+            "intervals": portion.open(1, 3) | portion.open(5, 7),
         },
         "26",
     ),
@@ -561,6 +579,6 @@ TEST_INTERVALS = [
 def test_intervals_to_str(test_input, expected):
     """Tests that the correct substrings are returned with defined intervals."""
 
-    str = intervals_to_str(test_input["str"], test_input["interval"])
+    str = intervals_to_str(**test_input)
 
     assert str == expected

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -34,20 +34,20 @@ import pytest
 # ),
 TEST_LISTS = [
     (
-        { "list1": [1,2,3],    "list2": [1,2,3,4], "fillValue": -1},
-        { "list1": [1,2,3,-1], "list2": [1,2,3,4]}
+        { "list1": [1,2],    "list2": [1,2,3], "fillValue": -1},
+        { "list1": [1,2,-1], "list2": [1,2,3]}
     ),
     (
-        { "list1": [1,2,3,4], "list2": [1,2,3], "fillValue": -1},
-        { "list1": [1,2,3,4], "list2": [1,2,3,-1]}
+        { "list1": [1,2],          "list2": [1,2,3,4,5], "fillValue": -1},
+        { "list1": [1,2,-1,-1,-1], "list2": [1,2,3,4,5]}
     ),
     (
-        { "list1": [1,2,3],          "list2": [1,2,3,4,5,6], "fillValue": -1},
-        { "list1": [1,2,3,-1,-1,-1], "list2": [1,2,3,4,5,6]}
+        { "list1": [1,2,3], "list2": [1,2], "fillValue": -1},
+        { "list1": [1,2,3], "list2": [1,2,-1]}
     ),
     (
-        { "list1": [1,2,3,4,5,6], "list2": [1,2,3], "fillValue": -1},
-        { "list1": [1,2,3,4,5,6], "list2": [1,2,3,-1,-1,-1]}
+        { "list1": [1,2,3,4,5], "list2": [1,2], "fillValue": -1},
+        { "list1": [1,2,3,4,5], "list2": [1,2,-1,-1,-1]}
     ),
     (
         { "list1": [], "list2": [], "fillValue": -1},
@@ -58,16 +58,16 @@ TEST_LISTS = [
         { "list1": [-1], "list2": [1]}
     ),
     (
+        { "list1": [],      "list2": [1,2], "fillValue": -1},
+        { "list1": [-1,-1], "list2": [1,2]}
+    ),
+    (
         { "list1": [1], "list2": [], "fillValue": -1},
         { "list1": [1], "list2": [-1]}
     ),
     (
-        { "list1": [],         "list2": [1,2,3], "fillValue": -1},
-        { "list1": [-1,-1,-1], "list2": [1,2,3]}
-    ),
-    (
-        { "list1": [1,2,3], "list2": [], "fillValue": -1},
-        { "list1": [1,2,3], "list2": [-1,-1,-1]}
+        { "list1": [1,2], "list2": [], "fillValue": -1},
+        { "list1": [1,2], "list2": [-1,-1]}
     ),
 ]
 
@@ -78,14 +78,66 @@ TEST_UNIFIED_DIFF_HEADERS = [
 ]
 
 TEST_UNIFIED_DIFFS = [
+    # 1 block. 1 minus line, 2 plus line
     (
         "@@ -1,2 +1,3 @@\n 1\n-2\n+2!\n+3!\n",
-        ([DiffLine("2", 2, 2), DiffLine("")], [DiffLine("2!", 2, 3), DiffLine("3!", 4, 3)])
+        ([DiffLine("2", 2, 2), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3)])
     ),
+    # 1 block. 1 minus line, 4 plus line
+    (
+        "@@ -1,2 +1,5 @@\n 1\n-2\n+2!\n+3!\n+4!\n+5!\n",
+        ([DiffLine("2", 2, 2), DiffLine(""), DiffLine(""), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 5, 4), DiffLine("5!", 6, 5)])
+    ),
+    # 2 blocks. Block 1: 1 minus line, 2 plus line. Block 2: 1 minus line, 2 plus line.
+    (
+        "@@ -1,4 +1,6 @@\n 1\n-2\n+2!\n+3!\n \n-4\n+4!\n+5!\n",
+        ([DiffLine("2", 2, 2), DiffLine(""), DiffLine("4", 6, 4), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6)])
+    ),
+    # 2 blocks. Block 1: 1 minus line, 4 plus line. Block 2: 1 minus line, 4 plus line.
+    (
+        "@@ -1,4 +1,10 @@\n 1\n-2\n+2!\n+3!\n+4!\n+5!\n \n-6\n+6!\n+7!\n+8!\n+9!\n",
+        ([DiffLine("2", 2, 2), DiffLine(""), DiffLine(""), DiffLine(""), DiffLine("6", 8, 4), DiffLine(""), DiffLine(""), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 5, 4), DiffLine("5!", 6, 5), DiffLine("6!", 9, 7), DiffLine("7!", 10, 8), DiffLine("8!", 11, 9), DiffLine("9!", 12, 10)])
+    ),
+    # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 1 minus line, 2 plus line.
+    (
+        "@@ -1,5 +1,6 @@\n 1\n-2\n-3\n+2!\n+3!\n \n-4\n+4!\n+5!\n",
+        ([DiffLine("2", 2, 2), DiffLine("3", 3, 3), DiffLine("4", 7, 5), DiffLine("")], [DiffLine("2!", 4, 2), DiffLine("3!", 5, 3), DiffLine("4!", 8, 5), DiffLine("5!", 9, 6)])
+    ),
+    # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 1 minus line, 4 plus line.
+    (
+        "@@ -1,5 +1,8 @@\n 1\n-2\n-3\n+2!\n+3!\n \n-4\n+4!\n+5!\n+6!\n+7!\n",
+        ([DiffLine("2", 2, 2), DiffLine("3", 3, 3), DiffLine("4", 7, 5), DiffLine(""), DiffLine(""), DiffLine("")], [DiffLine("2!", 4, 2), DiffLine("3!", 5, 3), DiffLine("4!", 8, 5), DiffLine("5!", 9, 6), DiffLine("6!", 10, 7), DiffLine("7!", 11, 8)])
+    ),
+    # 1 block. 2 minus line, 1 plus line
     (
         "@@ -1,3 +1,2 @@\n 1\n-2!\n-3!\n+2\n",
         ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3)], [DiffLine("2", 4, 2), DiffLine("")])
-    )
+    ),
+    # 1 block. 4 minus line, 1 plus line
+    (
+        "@@ -1,5 +1,2 @@\n 1\n-2!\n-3!\n-4!\n-5!\n+2\n",
+        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 4, 4), DiffLine("5!", 5, 5)], [DiffLine("2", 6, 2), DiffLine(""), DiffLine(""), DiffLine("")])
+    ),
+    # 2 blocks. Block 1: 2 minus line, 1 plus line. Block 2: 2 minus line, 1 plus line.
+    (
+        "@@ -1,6 +1,4 @@\n 1\n-2!\n-3!\n+2\n \n-4!\n-5!\n+4\n",
+        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 6, 5), DiffLine("5!", 7, 6)], [DiffLine("2", 4, 2), DiffLine(""), DiffLine("4", 8, 4), DiffLine("")])
+    ),
+    # 2 blocks. Block 1: 4 minus line, 1 plus line. Block 2: 4 minus line, 1 plus line.
+    (
+        "@@ -1,10 +1,4 @@\n 1\n-2!\n-3!\n-4!\n-5!\n+2\n \n-6!\n-7!\n-8!\n-9!\n+6\n",
+        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 4, 4), DiffLine("5!", 5, 5), DiffLine("6!", 8, 7), DiffLine("7!", 9, 8), DiffLine("8!", 10, 9), DiffLine("9!", 11, 10)], [DiffLine("2", 6, 2), DiffLine(""), DiffLine(""), DiffLine(""), DiffLine("6", 12, 4), DiffLine(""), DiffLine(""), DiffLine("")])
+    ),
+    # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 2 minus line, 1 plus line.
+    (
+        "@@ -1,6 +1,5 @@\n 1\n-2!\n-3!\n+2\n+3\n \n-4!\n-5!\n+4\n",
+        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6)], [DiffLine("2", 4, 2), DiffLine("3", 5, 3), DiffLine("4", 9, 5), DiffLine("")])
+    ),
+    # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 4 minus line, 1 plus line.
+    (
+        "@@ -1,8 +1,5 @@\n 1\n-2!\n-3!\n+2\n+3\n \n-4!\n-5!\n-6!\n-7!\n+4\n",
+        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6), DiffLine("6!", 9, 7), DiffLine("7!", 10, 8)], [DiffLine("2", 4, 2), DiffLine("3", 5, 3), DiffLine("4", 11, 5), DiffLine(""), DiffLine(""), DiffLine("")])
+    ),
 ]
 
 """Tests for Unified Diff functions."""
@@ -120,12 +172,14 @@ def test_align_diff_lines(test_input, expected):
     # TODO : Is it wrong to do splitlines here? Nice to save space in the test list
     line_list1, line_list2 = align_diff_lines(test_input.splitlines())
 
-    print(line_list1[0].diff_line_number)
-    print(expected[0][0].diff_line_number)
+    assert len(line_list1) == len(expected[0])
+    assert len(line_list2) == len(expected[1])
 
     for line, expected_line in zip(line_list1, expected[0]):
-        print(line.text + " " + expected_line.text)
-        print(line.text + " " + expected_line.text)
         assert line.text == expected_line.text
+        assert line.diff_line_number == expected_line.diff_line_number
+        assert line.file_line_number == expected_line.file_line_number
+
+    for line, expected_line in zip(line_list2, expected[1]):
         assert line.diff_line_number == expected_line.diff_line_number
         assert line.file_line_number == expected_line.file_line_number

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -186,6 +186,45 @@ TEST_DIFFLINES = [
     ),
 ]
 
+TEST_ISSUE_DICT_INPUT = [
+    (
+        {
+            "minus_line": DiffLine("example 123", 1, 2),
+            "plus_line": DiffLine("example 456", 3, 4),
+            "minus_str": "123",
+            "plus_str": "456",
+            "flag": None 
+        },
+        {
+            "minus_file_line_number": 2,
+            "plus_file_line_number": 4,
+            "minus_diff_line_number": 1,
+            "plus_diff_line_number": 3,
+            "minus_unmatched_str": "123",
+            "plus_unmatched_str": "456",
+        }
+    ),
+    (
+        {
+            "minus_line": DiffLine("example 123", 1, 2),
+            "plus_line": DiffLine("example 456", 3, 4),
+            "minus_str": "123",
+            "plus_str": "456",
+            "flag": get_test_flag()
+        },
+        {
+            "id": "test_flag",
+            "description": "test flag",
+            "minus_file_line_number": 2,
+            "plus_file_line_number": 4,
+            "minus_diff_line_number": 1,
+            "plus_diff_line_number": 3,
+            "minus_matched_str": "123",
+            "plus_matched_str": "456",
+        }
+    )
+]
+
 """Tests for Unified Diff functions."""
 
 # def test_Diff():
@@ -240,3 +279,17 @@ def test_issues_from_difflines(test_input, expected):
     assert unknown == expected["unknown"]
     assert minus_unmatched == expected["minus_unmatched"]
     assert plus_unmatched == expected["plus_unmatched"]
+
+@pytest.mark.parametrize("test_input, expected", TEST_ISSUE_DICT_INPUT)
+def test_make_issue_dict(test_input, expected):
+    """Tests that the dict is created properly."""
+
+    dict = make_issue_dict(
+        test_input["minus_line"],
+        test_input["plus_line"],
+        test_input["minus_str"],
+        test_input["plus_str"],
+        test_input["flag"],
+    )
+
+    assert dict == expected

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -466,9 +466,6 @@ def test_Diff_to_dict(test_input, expected):
     """Ensures Diff properly converts to a dict"""
 
     dict = test_input.to_dict()
-    print("asdf")
-    print(dict)
-    print(expected)
 
     assert dict == expected
 

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -81,63 +81,67 @@ TEST_UNIFIED_DIFFS = [
     # 1 block. 1 minus line, 2 plus line
     (
         "@@ -1,2 +1,3 @@\n 1\n-2\n+2!\n+3!\n",
-        ([DiffLine("2", 2, 2), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3)])
+        { "list1": [DiffLine("2", 2, 2), DiffLine("")], "list2": [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3)]}
     ),
     # 1 block. 1 minus line, 4 plus line
     (
         "@@ -1,2 +1,5 @@\n 1\n-2\n+2!\n+3!\n+4!\n+5!\n",
-        ([DiffLine("2", 2, 2), DiffLine(""), DiffLine(""), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 5, 4), DiffLine("5!", 6, 5)])
+        { "list1": [DiffLine("2", 2, 2), DiffLine(""), DiffLine(""), DiffLine("")], "list2": [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 5, 4), DiffLine("5!", 6, 5)]}
     ),
     # 2 blocks. Block 1: 1 minus line, 2 plus line. Block 2: 1 minus line, 2 plus line.
     (
         "@@ -1,4 +1,6 @@\n 1\n-2\n+2!\n+3!\n \n-4\n+4!\n+5!\n",
-        ([DiffLine("2", 2, 2), DiffLine(""), DiffLine("4", 6, 4), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6)])
+        { "list1": [DiffLine("2", 2, 2), DiffLine(""), DiffLine("4", 6, 4), DiffLine("")], "list2": [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6)]}
     ),
     # 2 blocks. Block 1: 1 minus line, 4 plus line. Block 2: 1 minus line, 4 plus line.
     (
         "@@ -1,4 +1,10 @@\n 1\n-2\n+2!\n+3!\n+4!\n+5!\n \n-6\n+6!\n+7!\n+8!\n+9!\n",
-        ([DiffLine("2", 2, 2), DiffLine(""), DiffLine(""), DiffLine(""), DiffLine("6", 8, 4), DiffLine(""), DiffLine(""), DiffLine("")], [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 5, 4), DiffLine("5!", 6, 5), DiffLine("6!", 9, 7), DiffLine("7!", 10, 8), DiffLine("8!", 11, 9), DiffLine("9!", 12, 10)])
+        { "list1": [DiffLine("2", 2, 2), DiffLine(""), DiffLine(""), DiffLine(""), DiffLine("6", 8, 4), DiffLine(""), DiffLine(""), DiffLine("")], "list2": [DiffLine("2!", 3, 2), DiffLine("3!", 4, 3), DiffLine("4!", 5, 4), DiffLine("5!", 6, 5), DiffLine("6!", 9, 7), DiffLine("7!", 10, 8), DiffLine("8!", 11, 9), DiffLine("9!", 12, 10)]}
     ),
     # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 1 minus line, 2 plus line.
     (
         "@@ -1,5 +1,6 @@\n 1\n-2\n-3\n+2!\n+3!\n \n-4\n+4!\n+5!\n",
-        ([DiffLine("2", 2, 2), DiffLine("3", 3, 3), DiffLine("4", 7, 5), DiffLine("")], [DiffLine("2!", 4, 2), DiffLine("3!", 5, 3), DiffLine("4!", 8, 5), DiffLine("5!", 9, 6)])
+        { "list1": [DiffLine("2", 2, 2), DiffLine("3", 3, 3), DiffLine("4", 7, 5), DiffLine("")], "list2": [DiffLine("2!", 4, 2), DiffLine("3!", 5, 3), DiffLine("4!", 8, 5), DiffLine("5!", 9, 6)]}
     ),
     # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 1 minus line, 4 plus line.
     (
         "@@ -1,5 +1,8 @@\n 1\n-2\n-3\n+2!\n+3!\n \n-4\n+4!\n+5!\n+6!\n+7!\n",
-        ([DiffLine("2", 2, 2), DiffLine("3", 3, 3), DiffLine("4", 7, 5), DiffLine(""), DiffLine(""), DiffLine("")], [DiffLine("2!", 4, 2), DiffLine("3!", 5, 3), DiffLine("4!", 8, 5), DiffLine("5!", 9, 6), DiffLine("6!", 10, 7), DiffLine("7!", 11, 8)])
+        { "list1": [DiffLine("2", 2, 2), DiffLine("3", 3, 3), DiffLine("4", 7, 5), DiffLine(""), DiffLine(""), DiffLine("")], "list2": [DiffLine("2!", 4, 2), DiffLine("3!", 5, 3), DiffLine("4!", 8, 5), DiffLine("5!", 9, 6), DiffLine("6!", 10, 7), DiffLine("7!", 11, 8)]}
     ),
     # 1 block. 2 minus line, 1 plus line
     (
         "@@ -1,3 +1,2 @@\n 1\n-2!\n-3!\n+2\n",
-        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3)], [DiffLine("2", 4, 2), DiffLine("")])
+        { "list1": [DiffLine("2!", 2, 2), DiffLine("3!", 3, 3)], "list2": [DiffLine("2", 4, 2), DiffLine("")]}
     ),
     # 1 block. 4 minus line, 1 plus line
     (
         "@@ -1,5 +1,2 @@\n 1\n-2!\n-3!\n-4!\n-5!\n+2\n",
-        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 4, 4), DiffLine("5!", 5, 5)], [DiffLine("2", 6, 2), DiffLine(""), DiffLine(""), DiffLine("")])
+        { "list1": [DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 4, 4), DiffLine("5!", 5, 5)], "list2": [DiffLine("2", 6, 2), DiffLine(""), DiffLine(""), DiffLine("")]}
     ),
     # 2 blocks. Block 1: 2 minus line, 1 plus line. Block 2: 2 minus line, 1 plus line.
     (
         "@@ -1,6 +1,4 @@\n 1\n-2!\n-3!\n+2\n \n-4!\n-5!\n+4\n",
-        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 6, 5), DiffLine("5!", 7, 6)], [DiffLine("2", 4, 2), DiffLine(""), DiffLine("4", 8, 4), DiffLine("")])
+        { "list1": [DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 6, 5), DiffLine("5!", 7, 6)], "list2": [DiffLine("2", 4, 2), DiffLine(""), DiffLine("4", 8, 4), DiffLine("")]}
     ),
     # 2 blocks. Block 1: 4 minus line, 1 plus line. Block 2: 4 minus line, 1 plus line.
     (
         "@@ -1,10 +1,4 @@\n 1\n-2!\n-3!\n-4!\n-5!\n+2\n \n-6!\n-7!\n-8!\n-9!\n+6\n",
-        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 4, 4), DiffLine("5!", 5, 5), DiffLine("6!", 8, 7), DiffLine("7!", 9, 8), DiffLine("8!", 10, 9), DiffLine("9!", 11, 10)], [DiffLine("2", 6, 2), DiffLine(""), DiffLine(""), DiffLine(""), DiffLine("6", 12, 4), DiffLine(""), DiffLine(""), DiffLine("")])
+        { "list1": [DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 4, 4), DiffLine("5!", 5, 5), DiffLine("6!", 8, 7), DiffLine("7!", 9, 8), DiffLine("8!", 10, 9), DiffLine("9!", 11, 10)], "list2": [DiffLine("2", 6, 2), DiffLine(""), DiffLine(""), DiffLine(""), DiffLine("6", 12, 4), DiffLine(""), DiffLine(""), DiffLine("")]}
     ),
     # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 2 minus line, 1 plus line.
     (
         "@@ -1,6 +1,5 @@\n 1\n-2!\n-3!\n+2\n+3\n \n-4!\n-5!\n+4\n",
-        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6)], [DiffLine("2", 4, 2), DiffLine("3", 5, 3), DiffLine("4", 9, 5), DiffLine("")])
+        { "list1": [DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6)], "list2": [DiffLine("2", 4, 2), DiffLine("3", 5, 3), DiffLine("4", 9, 5), DiffLine("")]}
     ),
     # 2 blocks. Block 1: 2 minus line, 2 plus line. Block 2: 4 minus line, 1 plus line.
     (
         "@@ -1,8 +1,5 @@\n 1\n-2!\n-3!\n+2\n+3\n \n-4!\n-5!\n-6!\n-7!\n+4\n",
-        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6), DiffLine("6!", 9, 7), DiffLine("7!", 10, 8)], [DiffLine("2", 4, 2), DiffLine("3", 5, 3), DiffLine("4", 11, 5), DiffLine(""), DiffLine(""), DiffLine("")])
+        { "list1": [DiffLine("2!", 2, 2), DiffLine("3!", 3, 3), DiffLine("4!", 7, 5), DiffLine("5!", 8, 6), DiffLine("6!", 9, 7), DiffLine("7!", 10, 8)], "list2": [DiffLine("2", 4, 2), DiffLine("3", 5, 3), DiffLine("4", 11, 5), DiffLine(""), DiffLine(""), DiffLine("")]}
     ),
+]
+
+TEST_DIFFLINES = [
+    ()
 ]
 
 """Tests for Unified Diff functions."""
@@ -172,14 +176,18 @@ def test_align_diff_lines(test_input, expected):
     # TODO : Is it wrong to do splitlines here? Nice to save space in the test list
     line_list1, line_list2 = align_diff_lines(test_input.splitlines())
 
-    assert len(line_list1) == len(expected[0])
-    assert len(line_list2) == len(expected[1])
+    assert len(line_list1) == len(expected["list1"])
+    assert len(line_list2) == len(expected["list2"])
 
-    for line, expected_line in zip(line_list1, expected[0]):
+    for line, expected_line in zip(line_list1, expected["list1"]):
         assert line.text == expected_line.text
         assert line.diff_line_number == expected_line.diff_line_number
         assert line.file_line_number == expected_line.file_line_number
 
-    for line, expected_line in zip(line_list2, expected[1]):
+    for line, expected_line in zip(line_list2, expected["list2"]):
         assert line.diff_line_number == expected_line.diff_line_number
         assert line.file_line_number == expected_line.file_line_number
+
+# @pytest.mark.paramtrise("test_input, expected", )
+# def test_issues_from_difflines(test_input, expected):
+#     """Tests that issues are correctly flagged, and intervals are updated correctly"""

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -402,7 +402,6 @@ TEST_UNIFIED_DIFFS = [
 def test_align_diff_lines(test_input, expected):
     """Tests that lines in unified diff get aligned as expected."""
 
-    # TODO : Is it wrong to do splitlines here? Nice to save space in the test list
     line_list1, line_list2 = align_diff_lines(test_input.splitlines())
 
     assert len(line_list1) == len(expected["list1"])
@@ -410,7 +409,6 @@ def test_align_diff_lines(test_input, expected):
 
     for line, expected_line in zip(line_list1, expected["list1"]):
         assert line == expected_line
-
     for line, expected_line in zip(line_list2, expected["list2"]):
         assert line == expected_line
 

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -40,7 +40,7 @@ from vessel.utils.unified_diff import (
 )
 
 # -----------------------------------------------------------------------------
-# Tests for Diff.to_dict
+# Tests for Diff.to_slim_dict
 # -----------------------------------------------------------------------------
 
 TEST_DIFF_CLASS_OBJECTS = [
@@ -65,10 +65,10 @@ TEST_DIFF_CLASS_OBJECTS = [
 
 
 @pytest.mark.parametrize("test_input, expected", TEST_DIFF_CLASS_OBJECTS)
-def test_Diff_to_dict(test_input, expected):
+def test_Diff_to_sim_dict(test_input, expected):
     """Ensures Diff properly converts to a dict"""
 
-    dict = test_input.to_dict()
+    dict = test_input.to_slim_dict()
 
     assert dict == expected
 

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -389,6 +389,17 @@ TEST_DIFFLINES = [
 
 TEST_ISSUE_DICT_INPUT = [
     (
+        {},
+        {
+            "minus_file_line_number": None,
+            "plus_file_line_number": None,
+            "minus_diff_line_number": None,
+            "plus_diff_line_number": None,
+            "minus_unmatched_str": None,
+            "plus_unmatched_str": None,
+        },
+    ),
+    (
         {
             "minus_line": DiffLine("example 123", 1, 2),
             "plus_line": DiffLine("example 456", 3, 4),
@@ -521,13 +532,7 @@ def test_issues_from_difflines(test_input, expected):
 def test_make_issue_dict(test_input, expected):
     """Tests that the dict is created properly."""
 
-    dict = make_issue_dict(
-        test_input["minus_line"],
-        test_input["plus_line"],
-        test_input["minus_str"],
-        test_input["plus_str"],
-        test_input["flag"],
-    )
+    dict = make_issue_dict(**test_input)
 
     assert dict == expected
 

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -385,13 +385,10 @@ def test_align_diff_lines(test_input, expected):
     assert len(line_list2) == len(expected["list2"])
 
     for line, expected_line in zip(line_list1, expected["list1"]):
-        assert line.text == expected_line.text
-        assert line.diff_line_number == expected_line.diff_line_number
-        assert line.file_line_number == expected_line.file_line_number
+        assert line == expected_line
 
     for line, expected_line in zip(line_list2, expected["list2"]):
-        assert line.diff_line_number == expected_line.diff_line_number
-        assert line.file_line_number == expected_line.file_line_number
+        assert line == expected_line
 
 
 # -----------------------------------------------------------------------------

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -80,9 +80,10 @@ def test_Diff_to_dict(test_input, expected):
 TEST_DIFFLINE_DATA = [
     (
         {"text": "012345", "diff_line_number": 7, "file_line_number": 8},
-        {"text": "012345", "diff_line_number": 7, "file_line_number": 8}
+        {"text": "012345", "diff_line_number": 7, "file_line_number": 8},
     )
 ]
+
 
 @pytest.mark.parametrize("test_input, expected", TEST_DIFFLINE_DATA)
 def test_DiffLine(test_input, expected):
@@ -92,7 +93,10 @@ def test_DiffLine(test_input, expected):
 
     assert diffline.diff_line_number == expected["diff_line_number"]
     assert diffline.file_line_number == expected["file_line_number"]
-    assert intervals_to_str(diffline.text, diffline.unmatched_intervals) == expected["text"]
+    assert (
+        intervals_to_str(diffline.text, diffline.unmatched_intervals)
+        == expected["text"]
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -477,7 +481,9 @@ TEST_DIFFLINES = [
 def test_issues_from_difflines(test_input, expected):
     """Tests that issues are correctly flagged, and intervals are updated correctly"""
 
-    flagged, unknown, minus_unmatched, plus_unmatched = issues_from_difflines(**test_input)
+    flagged, unknown, minus_unmatched, plus_unmatched = issues_from_difflines(
+        **test_input
+    )
 
     assert flagged == expected["flagged"]
     assert unknown == expected["unknown"]
@@ -554,10 +560,19 @@ def test_make_issue_dict(test_input, expected):
 # -----------------------------------------------------------------------------
 
 TEST_INTERVALS = [
-    ({"input_string": "0123456789", "intervals": portion.closed(3, 6)}, "3456"),
+    (
+        {"input_string": "0123456789", "intervals": portion.closed(3, 6)},
+        "3456",
+    ),
     ({"input_string": "0123456789", "intervals": portion.open(3, 6)}, "45"),
-    ({"input_string": "0123456789", "intervals": portion.openclosed(3, 6)}, "456"),
-    ({"input_string": "0123456789", "intervals": portion.closedopen(3, 6)}, "345"),
+    (
+        {"input_string": "0123456789", "intervals": portion.openclosed(3, 6)},
+        "456",
+    ),
+    (
+        {"input_string": "0123456789", "intervals": portion.closedopen(3, 6)},
+        "345",
+    ),
     (
         {
             "input_string": "0123456789",

--- a/test/util/test_unified_diff.py
+++ b/test/util/test_unified_diff.py
@@ -1,0 +1,131 @@
+# Vessel Diff Tool
+#
+# Copyright 2024 Carnegie Mellon University.
+#
+# NO WARRANTY. THIS CARNEGIE MELLON UNIVERSITY AND SOFTWARE ENGINEERING
+# INSTITUTE MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. CARNEGIE MELLON
+# UNIVERSITY MAKES NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+# AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS
+# FOR PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM
+# USE OF THE MATERIAL. CARNEGIE MELLON UNIVERSITY DOES NOT MAKE ANY
+# WARRANTY OF ANY KIND WITH RESPECT TO FREEDOM FROM PATENT, TRADEMARK,
+# OR COPYRIGHT INFRINGEMENT.
+#
+# Licensed under a MIT (SEI)-style license, please see license.txt
+# or contact permission@sei.cmu.edu for full terms.
+#
+# [DISTRIBUTION STATEMENT A] This material has been approved for public
+# release and unlimited distribution.  Please see Copyright notice
+# for non-US Government use and distribution.
+#
+# This Software includes and/or makes use of Third-Party Software
+# each subject to its own license.
+#
+# DM24-1321
+
+from vessel.utils.unified_diff import equal_entry_list, parse_unified_diff_header, DiffLine, align_diff_lines
+
+import pytest
+
+# TODO : Does this need to handle DiffLine objects? the object compare breaks on hashes of the obj
+# (
+#     { "list1": [DiffLine("line1", None, None), DiffLine("line2", None, None)], "list2": [DiffLine("line3", None, None)], "fillValue": DiffLine("", None, None)},
+#     { "list1": [DiffLine("line1", None, None), DiffLine("line2", None, None)], "list2": [DiffLine("line3", None, None), DiffLine("", None, None)]}
+# ),
+TEST_LISTS = [
+    (
+        { "list1": [1,2,3],    "list2": [1,2,3,4], "fillValue": -1},
+        { "list1": [1,2,3,-1], "list2": [1,2,3,4]}
+    ),
+    (
+        { "list1": [1,2,3,4], "list2": [1,2,3], "fillValue": -1},
+        { "list1": [1,2,3,4], "list2": [1,2,3,-1]}
+    ),
+    (
+        { "list1": [1,2,3],          "list2": [1,2,3,4,5,6], "fillValue": -1},
+        { "list1": [1,2,3,-1,-1,-1], "list2": [1,2,3,4,5,6]}
+    ),
+    (
+        { "list1": [1,2,3,4,5,6], "list2": [1,2,3], "fillValue": -1},
+        { "list1": [1,2,3,4,5,6], "list2": [1,2,3,-1,-1,-1]}
+    ),
+    (
+        { "list1": [], "list2": [], "fillValue": -1},
+        { "list1": [], "list2": []}
+    ),
+    (
+        { "list1": [],   "list2": [1], "fillValue": -1},
+        { "list1": [-1], "list2": [1]}
+    ),
+    (
+        { "list1": [1], "list2": [], "fillValue": -1},
+        { "list1": [1], "list2": [-1]}
+    ),
+    (
+        { "list1": [],         "list2": [1,2,3], "fillValue": -1},
+        { "list1": [-1,-1,-1], "list2": [1,2,3]}
+    ),
+    (
+        { "list1": [1,2,3], "list2": [], "fillValue": -1},
+        { "list1": [1,2,3], "list2": [-1,-1,-1]}
+    ),
+]
+
+TEST_UNIFIED_DIFF_HEADERS = [
+    ("@@ -8,13 +15,13 @@", (8, 15)),
+    ("@@ -0,0 +1 @@", (0, 1)),
+    ("@@ -1 +0,0 @@", (1, 0))
+]
+
+TEST_UNIFIED_DIFFS = [
+    (
+        "@@ -1,2 +1,3 @@\n 1\n-2\n+2!\n+3!\n",
+        ([DiffLine("2", 2, 2), DiffLine("")], [DiffLine("2!", 2, 3), DiffLine("3!", 4, 3)])
+    ),
+    (
+        "@@ -1,3 +1,2 @@\n 1\n-2!\n-3!\n+2\n",
+        ([DiffLine("2!", 2, 2), DiffLine("3!", 3, 3)], [DiffLine("2", 4, 2), DiffLine("")])
+    )
+]
+
+"""Tests for Unified Diff functions."""
+
+# def test_Diff():
+#     assert False
+
+# def test_DiffLine():
+#     assert False
+
+@pytest.mark.parametrize("test_input, expected", TEST_LISTS)
+def test_equal_entry_list(test_input: dict, expected: dict):
+    """Tests that inputted lists are returned equal length with the correct fill value."""
+
+    equal_list1, equal_list2 = equal_entry_list(test_input["list1"], test_input["list2"], test_input["fillValue"])
+
+    assert equal_list1 == expected["list1"]
+    assert equal_list2 == expected["list2"]
+
+@pytest.mark.parametrize("test_input, expected", TEST_UNIFIED_DIFF_HEADERS)
+def test_parse_unified_diff_header(test_input: str, expected: tuple[int, int]):
+    """Tests that the unified diff header is parsed correctly to return start lines of the diffs."""
+
+    line_num1, line_num2 = parse_unified_diff_header(test_input)
+
+    assert (line_num1, line_num2) == expected
+
+@pytest.mark.parametrize("test_input, expected", TEST_UNIFIED_DIFFS)
+def test_align_diff_lines(test_input, expected):
+    """Tests that lines in unified diff get aligned as expected."""
+
+    # TODO : Is it wrong to do splitlines here? Nice to save space in the test list
+    line_list1, line_list2 = align_diff_lines(test_input.splitlines())
+
+    print(line_list1[0].diff_line_number)
+    print(expected[0][0].diff_line_number)
+
+    for line, expected_line in zip(line_list1, expected[0]):
+        print(line.text + " " + expected_line.text)
+        print(line.text + " " + expected_line.text)
+        assert line.text == expected_line.text
+        assert line.diff_line_number == expected_line.diff_line_number
+        assert line.file_line_number == expected_line.file_line_number

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -327,7 +327,7 @@ class DiffCommand:
             unknown_issue_count: Count of unknown issues
             flagged_issue_count: Count of flagged issues
             diffs: List of diffs, each being a dict item returned
-                    from Diff.to_dict()
+                    from Diff.to_slim_dict()
 
         Returns:
             None

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -279,7 +279,7 @@ def parse_diffoscope_output(
                     ),
                 )
 
-        diff_list.append(diff.to_dict())
+        diff_list.append(diff.to_slim_dict())
 
     # Recurvisely navigating through the tree
     if "details" in current_detail:

--- a/vessel/utils/unified_diff.py
+++ b/vessel/utils/unified_diff.py
@@ -66,8 +66,12 @@ class Diff:
             self.unified_diff,
         )
 
-    def to_dict(self: "Diff") -> dict:
-        """Returns diff object as a dict."""
+    def to_slim_dict(self: "Diff") -> dict:
+        """Returns diff object as a dict.
+
+        Returns a dict object only containing parts of the diff that are
+        populated. This is done to reduce the size of the output file.
+        """
         dict_obj: dict[str, Any] = {
             "source1": self.source1,
             "source2": self.source2,

--- a/vessel/utils/unified_diff.py
+++ b/vessel/utils/unified_diff.py
@@ -27,7 +27,7 @@
 
 import typing
 from logging import getLogger
-from typing import Any
+from typing import Any, Optional
 
 import portion  # type: ignore
 
@@ -92,8 +92,8 @@ class DiffLine:
     def __init__(
         self: "DiffLine",
         text: str,
-        diff_line_number: int | None,
-        file_line_number: int | None,
+        diff_line_number: Optional[int] = None,
+        file_line_number: Optional[int] = None,
     ) -> None:
         """Initializer for DiffLine class."""
         self.text = text
@@ -105,9 +105,9 @@ class DiffLine:
 
 
 def equal_entry_list(
-    list1: list,
-    list2: list,
-    fillvalue: Any | None = None,
+    list1: list[Any],
+    list2: list[Any],
+    fillvalue: Optional[Any] = None,
 ) -> tuple[list, list]:
     """Return two lists of even length with from two lists.
 
@@ -212,7 +212,7 @@ def align_diff_lines(
             minus_aligned_lines, plus_aligned_lines = equal_entry_list(
                 minus_aligned_lines,
                 plus_aligned_lines,
-                DiffLine("", None, None),
+                DiffLine(""),
             )
         else:
             minus_file_line_index += 1

--- a/vessel/utils/unified_diff.py
+++ b/vessel/utils/unified_diff.py
@@ -103,6 +103,16 @@ class DiffLine:
         #   have not been matched by any of the flag['indiff'] regex
         self.unmatched_intervals = portion.closed(0, len(self.text) - 1)
 
+    def __eq__(self, other: object):
+        if isinstance(other, DiffLine):
+            return (
+                self.text == other.text
+                and self.diff_line_number == other.diff_line_number
+                and self.file_line_number == self.file_line_number
+                and self.unmatched_intervals == other.unmatched_intervals
+            )
+        return False
+
 
 def equal_entry_list(
     list1: list[Any],

--- a/vessel/utils/unified_diff.py
+++ b/vessel/utils/unified_diff.py
@@ -100,7 +100,7 @@ class DiffLine:
         self.diff_line_number = diff_line_number
         self.file_line_number = file_line_number
         # Interval object containing the range of self.text that
-        # have not been matched by any of the flag['indiff'] regex
+        #   have not been matched by any of the flag['indiff'] regex
         self.unmatched_intervals = portion.closed(0, len(self.text) - 1)
 
 
@@ -287,9 +287,10 @@ def issues_from_difflines(
                 minus_line.text,
                 portion.closed(
                     minus_match_interval[0],
-                    minus_match_interval[1],
+                    minus_match_interval[1] - 1,
                 ),
             )
+
         plus_match_str = ""
         if plus_match_interval is not None:
             plus_line.unmatched_intervals = (
@@ -301,7 +302,7 @@ def issues_from_difflines(
             )
             plus_match_str = intervals_to_str(
                 plus_line.text,
-                portion.closed(plus_match_interval[0], plus_match_interval[1]),
+                portion.closed(plus_match_interval[0], plus_match_interval[1] - 1),
             )
 
         if minus_match_interval is None:
@@ -342,16 +343,18 @@ def issues_from_difflines(
 
 
 def make_issue_dict(
-    minus_line: DiffLine | None,
-    plus_line: DiffLine | None,
-    minus_str: str | None,
-    plus_str: str | None,
-    flag: Flag | None = None,
+    minus_line: Optional[DiffLine] = None,
+    plus_line: Optional[DiffLine] = None,
+    minus_str: Optional[str] = None,
+    plus_str: Optional[str] = None,
+    flag: Optional[Flag] = None,
 ) -> dict[str, Any]:
     """Create issue dict object.
 
     Used to ensure consistency in all issue objects that
-    will be written to final output file.
+    will be written to final output file. A flag being passed
+    implies that it was a flagged issue and the flag information
+    will be embedded in the dict.
 
     Args:
         minus_line: Diff line object containing the minus line

--- a/vessel/utils/unified_diff.py
+++ b/vessel/utils/unified_diff.py
@@ -413,7 +413,7 @@ def intervals_to_str(
     Returns string containing the characters in the input string
     that are in the ranges specifiec by the interval parameter.
     Appriately handles open and closed ends of the intervals used
-    by the Portion library.
+    by the Portion library. Does not handle singleton.
 
     Args:
         input_string: String to take sections out of

--- a/vessel/utils/unified_diff.py
+++ b/vessel/utils/unified_diff.py
@@ -302,7 +302,9 @@ def issues_from_difflines(
             )
             plus_match_str = intervals_to_str(
                 plus_line.text,
-                portion.closed(plus_match_interval[0], plus_match_interval[1] - 1),
+                portion.closed(
+                    plus_match_interval[0], plus_match_interval[1] - 1
+                ),
             )
 
         if minus_match_interval is None:

--- a/vessel/utils/unified_diff.py
+++ b/vessel/utils/unified_diff.py
@@ -117,7 +117,7 @@ class DiffLine:
 def equal_entry_list(
     list1: list[Any],
     list2: list[Any],
-    fillvalue: Optional[Any] = None,
+    fill_value: Optional[Any] = None,
 ) -> tuple[list, list]:
     """Return two lists of even length with from two lists.
 
@@ -138,9 +138,9 @@ def equal_entry_list(
     #           give better unified diffs. Very hard to line up lines without
     #           context
     while len(list1) < len(list2):
-        list1.append(fillvalue)
+        list1.append(fill_value)
     while len(list2) < len(list1):
-        list2.append(fillvalue)
+        list2.append(fill_value)
 
     return list1, list2
 


### PR DESCRIPTION
Adding unit tests for the `unified_diff.py` file.

Open to feedback on quality of tests, missing cases, formatting etc and had a couple points of discussion.

1. The comment on like 61. The `equal_entry_lists` function accepts objects of `Any` type as the `fillValue` to append to the list. The tool only ever passes `None`, or an empty `DiffLine` object. I wrote the tests with just ints for simplicity, and wanted to add `DiffLine` objects, but because assert looks at the hashes of the objects, they are not evaluated to be equal even when their contents are the same. Then handling them as a case to compare the contents would break the int tests. Do we think that it is necessary to handle a case for `DiffLine` objects, or because it correctly appends the `fillValue` with ints, we assume it works for any passes object?
2. The test inputs are very long to account for all the cases of these functions, but they are unlikely to be re-used by any functions of other test files. Do we want to make a separate fixture just for this test file, or include them all in one file as I have it now?
3. Any feedback on the tests for `Diff` class and lack of tests for `DiffLine` class. I wrote a simple test for `Diff.to_dict()` but doesn't handle some of the cases where the flagged/unknown issues wouldn't be empty which happens external to the class. While typing, I suppose this would probably be a case for having the functionality for those to be updated as class methods instead of just assignments from other pieces of code. Would that be the best solution there? Then `DiffLine` would likely follow a similar path, with less options because only the `unmatched_intervals` of that class ever change.