### PR TITLE
Add check to ignore /tmp/diffoscope recursion

### DIFF
--- a/test/fixture.py
+++ b/test/fixture.py
@@ -44,13 +44,13 @@ def get_test_flag():
 def get_test_diffoscope_output():
     return {
         "diffoscope-json-version": 1,
-        "source1": "/example_path1/rootfs",
-        "source2": "/example_path2/rootfs",
+        "source1": "/umoci-unpack-example_path1/rootfs",
+        "source2": "/umoci-unpack-example_path2/rootfs",
         "unified_diff": None,
         "details": [
             {
-                "source1": "/example_path1/rootfs/app",
-                "source2": "/example_path2/rootfs/app",
+                "source1": "/umoci-unpack-example_path1/rootfs/app",
+                "source2": "/umoci-unpack-example_path2/rootfs/app",
                 "unified_diff": None,
                 "details": [
                     {
@@ -59,8 +59,8 @@ def get_test_diffoscope_output():
                         "unified_diff": "@@ -1,8 +1,8 @@\n \n   Size: 4096      \tBlocks: 8          IO Block: 4096   directory\n Device: 0,72\tLinks: 3\n Access: (0755/drwxr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)\n \n+Modify: 2024-12-03 21:14:59.000000000 +0000\n-Modify: 2024-12-03 20:54:07.000000000 +0000\n \n \n",
                     },
                     {
-                        "source1": "/example_path1/rootfs/app/cmd",
-                        "source2": "/example_path2/rootfs/app/cmd",
+                        "source1": "/umoci-unpack-example_path1/rootfs/app/cmd",
+                        "source2": "/umoci-unpack-example_path2/rootfs/app/cmd",
                         "unified_diff": None,
                         "details": [
                             {
@@ -69,8 +69,8 @@ def get_test_diffoscope_output():
                                 "unified_diff": "@@ -1,8 +1,8 @@\n \n   Size: 4096      \tBlocks: 8          IO Block: 4096   directory\n Device: 0,72\tLinks: 3\n Access: (0755/drwxr-xr-x)  Uid: (    0/    root)   Gid: (    0/    root)\n \n-Modify: 2024-12-03 20:54:07.000000000 +0000\n+Modify: 2024-12-03 21:14:59.000000000 +0000\n \n \n",
                             },
                             {
-                                "source1": "/example_path1/rootfs/app/cmd/acmesolver",
-                                "source2": "/example_path2/rootfs/app/cmd/acmesolver",
+                                "source1": "/umoci-unpack-example_path1/rootfs/app/cmd/acmesolver",
+                                "source2": "/umoci-unpack-example_path2/rootfs/app/cmd/acmesolver",
                                 "unified_diff": None,
                                 "details": [
                                     {
@@ -100,8 +100,8 @@ def get_test_diffoscope_output():
                 ],
             },
             {
-                "source1": "/example_path1/rootfs/licenses",
-                "source2": "/example_path2/rootfs/licenses",
+                "source1": "/umoci-unpack-example_path1/rootfs/licenses",
+                "source2": "/umoci-unpack-example_path2/rootfs/licenses",
                 "unified_diff": None,
                 "details": [
                     {

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -355,11 +355,12 @@ def parse_diffoscope_output(
 
     # Recurvisely navigating through the tree
     if "details" in current_detail:
-        umociRegex = re.compile(r"/umoci-unpack-output_")
+        umociRegex = re.compile(r"/umoci-unpack-")
 
         for child in current_detail["details"]:
             # Ignore anything without the full umoci-unpack-putput_ path that shouldn't be showing in diffs
-            if (child["source1"][0] != "/"
+            if (
+                child["source1"][0] != "/"
                 or child["source2"][0] != "/"
                 or umociRegex.search(child["source1"])
                 or umociRegex.search(child["source2"])

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -349,7 +349,11 @@ def parse_diffoscope_output(
     if "details" in current_detail:
         for child in current_detail["details"]:
             # Ignore anything without our full /tmp/diffoscope path that shouldn't be showing in diffs
-            if not re.compile(r"/tmp/diffoscope_*").search(child["source1"]) and not re.compile(r"/tmp/diffoscope_*").search(child["source2"]):
+            if not re.compile(r"/tmp/diffoscope_*").search(
+                child["source1"]
+            ) and not re.compile(r"/tmp/diffoscope_*").search(
+                child["source2"]
+            ):
                 child_return = parse_diffoscope_output(
                     child,
                     flags,

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -348,19 +348,22 @@ def parse_diffoscope_output(
     # Recurvisely navigating through the tree
     if "details" in current_detail:
         for child in current_detail["details"]:
-            child_return = parse_diffoscope_output(
-                child,
-                flags,
-                current_detail["source1"],
-                current_detail["source2"],
-                current_detail.get("comments"),
-                files_summary,
-                file_checksum=file_checksum,
-            )
-            unknown_issues_count += child_return[0]
-            trivial_issues_count += child_return[1]
-            nontrivial_issues_count += child_return[2]
-            diff_list.extend(child_return[3])
+            # Ignore anything without our full /tmp/diffoscope path that shouldn't be showing in diffs
+            if not re.compile(r"/tmp/diffoscope_*").search(child["source1"]) and not re.compile(r"/tmp/diffoscope_*").search(child["source2"]):
+                child_return = parse_diffoscope_output(
+                    child,
+                    flags,
+                    umoci_image_paths,
+                    current_detail["source1"],
+                    current_detail["source2"],
+                    current_detail.get("comments"),
+                    files_summary,
+                    file_checksum=file_checksum,
+                )
+                unknown_issues_count += child_return[0]
+                trivial_issues_count += child_return[1]
+                nontrivial_issues_count += child_return[2]
+                diff_list.extend(child_return[3])
 
     checksum_summary = {}
     # Only generate the final summary when it's top-level call (end of recursion)

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -355,11 +355,14 @@ def parse_diffoscope_output(
 
     # Recurvisely navigating through the tree
     if "details" in current_detail:
-        tmpRegex = re.compile(r"/tmp/diffoscope_*")
+        umociRegex = re.compile(r"/umoci-unpack-output_")
+
         for child in current_detail["details"]:
-            # Ignore anything without our full /tmp/diffoscope path that shouldn't be showing in diffs
-            if not tmpRegex.search(child["source1"]) and not tmpRegex.search(
-                child["source2"]
+            # Ignore anything without the full umoci-unpack-putput_ path that shouldn't be showing in diffs
+            if (child["source1"][0] != "/"
+                or child["source2"][0] != "/"
+                or umociRegex.search(child["source1"])
+                or umociRegex.search(child["source2"])
             ):
                 child_return = parse_diffoscope_output(
                     child,

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -358,7 +358,7 @@ def parse_diffoscope_output(
         umociRegex = re.compile(r"/umoci-unpack-")
 
         for child in current_detail["details"]:
-            # Ignore anything without the full umoci-unpack-putput_ path that shouldn't be showing in diffs
+            # Ignore anything without the umoci-unpack- path that shouldn't be showing in diffs
             if (
                 child["source1"][0] != "/"
                 or child["source2"][0] != "/"

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -365,7 +365,6 @@ def parse_diffoscope_output(
                 child_return = parse_diffoscope_output(
                     child,
                     flags,
-                    umoci_image_paths,
                     current_detail["source1"],
                     current_detail["source2"],
                     current_detail.get("comments"),

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -355,13 +355,10 @@ def parse_diffoscope_output(
 
     # Recurvisely navigating through the tree
     if "details" in current_detail:
+        tmpRegex = re.compile(r"/tmp/diffoscope_*")
         for child in current_detail["details"]:
             # Ignore anything without our full /tmp/diffoscope path that shouldn't be showing in diffs
-            if not re.compile(r"/tmp/diffoscope_*").search(
-                child["source1"]
-            ) and not re.compile(r"/tmp/diffoscope_*").search(
-                child["source2"]
-            ):
+            if not tmpRegex.search(child["source1"]) and not tmpRegex.search(child["source2"]):
                 child_return = parse_diffoscope_output(
                     child,
                     flags,

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -371,11 +371,10 @@ def parse_diffoscope_output(
                     files_summary,
                     file_checksum=file_checksum,
                 )
-                unknown_issues_count += child_return[0]
-                trivial_issues_count += child_return[1]
-                nontrivial_issues_count += child_return[2]
+                unknown_failures_count += child_return[0]
+                trivial_failures_count += child_return[1]
+                nontrivial_failures_count += child_return[2]
                 diff_list.extend(child_return[3])
-
 
     checksum_summary = {}
     # Only generate the final summary when it's top-level call (end of recursion)

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -358,7 +358,9 @@ def parse_diffoscope_output(
         tmpRegex = re.compile(r"/tmp/diffoscope_*")
         for child in current_detail["details"]:
             # Ignore anything without our full /tmp/diffoscope path that shouldn't be showing in diffs
-            if not tmpRegex.search(child["source1"]) and not tmpRegex.search(child["source2"]):
+            if not tmpRegex.search(child["source1"]) and not tmpRegex.search(
+                child["source2"]
+            ):
                 child_return = parse_diffoscope_output(
                     child,
                     flags,


### PR DESCRIPTION
Add simple check to ignore the `/tmp/diffoscope` files from making it into our final diff.

Wanted to go the route of checking if the `umoci-unpack` path was there, but wasn't sure how to implement while handling commands. In previous parts of code, I used Path().is_file() to determine if sources were a command or not, but because these tmp files are deleted, they will show up as not a file. Could implement a function/check to see if a string is pathlike but wasn't sure how robust it could be while ensuring we don't hit any commands. I feel this regex is sufficient as seeing a diff from something outside of the unpacked path seems like a one off edge case.