### PR TITLE
Enabling diff with checksum metadata and diffoscope output directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ FROM python:3.11-bookworm AS release
 # its specific diff plugins.
 RUN apt-get update && \
   apt-get install -y --allow-downgrades --no-install-recommends \
-    python3-dev \
-    build-essential \
+    python3-dev=3.11.2-1+b1 \
+    build-essential=12.9 \
     skopeo=1.9.3+ds1-1+b10 \
     umoci=0.4.7+ds-3+b7 \
     libmagic-dev=1:5.44-3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM python:3.11-bookworm AS release
 # its specific diff plugins.
 RUN apt-get update && \
   apt-get install -y --allow-downgrades --no-install-recommends \
+    python3-dev \
+    build-essential \
     skopeo=1.9.3+ds1-1+b10 \
     umoci=0.4.7+ds-3+b7 \
     libmagic-dev=1:5.44-3 \

--- a/test/util/test_checksum.py
+++ b/test/util/test_checksum.py
@@ -32,6 +32,7 @@ import pytest
 from vessel.utils.checksum import (
     FileHash,
     classify_checksum_mismatches,
+    generate_filesummary_and_checksum,
     hash_folder_contents,
     summarize_checksums,
 )
@@ -528,3 +529,56 @@ def test_classify_checksum_mismatches(test_input, expected):
     """Test classify_checksum_mismatches."""
     output = classify_checksum_mismatches(**test_input)
     assert output == expected
+
+
+def test_generate_filesummary_and_checksum_from_rootfs(tmp_path):
+    """Test generate_filesummary_and_checksum with two rootfs directories"""
+    rootfs1 = tmp_path / "rootfs1"
+    rootfs2 = tmp_path / "rootfs2"
+    rootfs1.mkdir()
+    rootfs2.mkdir()
+    (rootfs1 / "foo.txt").write_text("same_content")
+    (rootfs2 / "foo.txt").write_text("same_content")
+    (rootfs1 / "unique1.txt").write_text("only1")
+    (rootfs2 / "unique2.txt").write_text("only2")
+
+    files_summary, checksum_summary = generate_filesummary_and_checksum(
+        diff_list=[],
+        rootfs_path1=rootfs1,
+        rootfs_path2=rootfs2,
+    )
+
+    assert checksum_summary["total_common_files"] == 1
+    assert len(checksum_summary["only_in_image1"]) == 1
+    assert len(checksum_summary["only_in_image2"]) == 1
+    assert "unique1.txt" in checksum_summary["only_in_image1"][0]
+    assert "unique2.txt" in checksum_summary["only_in_image2"][0]
+    assert files_summary[0]["image1"] == str(rootfs1)
+    assert files_summary[0]["image2"] == str(rootfs2)
+
+
+def test_generate_filesummary_and_checksum_from_hashes():
+    """Test generate_filesummary_and_checksum using hashed metadata directly"""
+    hashed_files1 = {
+        "foo.txt": FileHash("foo.txt", "ASCII text", "hashsame"),
+        "bar.txt": FileHash("bar.txt", "ASCII text", "hashbar1"),
+    }
+    hashed_files2 = {
+        "foo.txt": FileHash("foo.txt", "ASCII text", "hashsame"),
+        "baz.txt": FileHash("baz.txt", "ASCII text", "hashbaz2"),
+    }
+
+    files_summary, checksum_summary = generate_filesummary_and_checksum(
+        diff_list=[],
+        hashed_files1=hashed_files1,
+        hashed_files2=hashed_files2,
+        image1_path="test_image1",
+        image2_path="test_image2",
+    )
+    assert checksum_summary["total_common_files"] == 1
+    assert len(checksum_summary["only_in_image1"]) == 1
+    assert len(checksum_summary["only_in_image2"]) == 1
+    assert checksum_summary["only_in_image1"][0] == "bar.txt"
+    assert checksum_summary["only_in_image2"][0] == "baz.txt"
+    assert files_summary[0]["image1"] == "test_image1"
+    assert files_summary[0]["image2"] == "test_image2"

--- a/test/util/test_diffoscope.py
+++ b/test/util/test_diffoscope.py
@@ -175,8 +175,6 @@ def test_parse_diffoscope_output_debug():
         trivial_failures,
         nontrivial_failures,
         diff_list,
-        files_summary,
-        checksum_summary,
     ) = parse_diffoscope_output(test_diff, [test_flag])
 
     assert unknown_failures == 0
@@ -185,5 +183,3 @@ def test_parse_diffoscope_output_debug():
     assert len(diff_list) > 0
     assert "flagged_failures" in diff_list[0]
     assert diff_list[0]["flagged_failures"][0]["id"] == "test_flag"
-    assert len(files_summary) > 0
-    assert checksum_summary["total_common_files"] == 0

--- a/vessel/cli.py
+++ b/vessel/cli.py
@@ -98,26 +98,11 @@ def vessel(logging_level: str) -> None:
         "in current directory."
     ),
 )
-@click.option(
-    "-f",
-    "--file-checksum",
-    type=click.Path(
-        file_okay=False,
-        readable=True,
-        writable=True,
-        resolve_path=True,
-    ),
-    help=(
-        "Enable this option if you would like to record checksum matches "
-        "and mismatches of the unpacked filesystem."
-    ),
-)
 def diff(
     input_files: list[str],
     compare_level: str,
     data_dir: str,
     output_dir: str,
-    file_checksum: bool,
 ) -> None:
     """Unpack container images and compare differences with diffoscope.
 
@@ -128,6 +113,5 @@ def diff(
         compare_level,
         data_dir,
         output_dir,
-        file_checksum,
     ).execute()
     sys.exit(not success)

--- a/vessel/cli.py
+++ b/vessel/cli.py
@@ -60,17 +60,6 @@ def vessel(logging_level: str) -> None:
     nargs=-1,
 )
 @click.option(
-    "-c",
-    "--compare-level",
-    type=click.Choice(["image", "file"]),
-    default="file",
-    show_default=True,
-    help=(
-        "Diff mode selection: 'image' for image tar or file' for final image "
-        "filesystem. Default 'file'"
-    ),
-)
-@click.option(
     "-d",
     "--data-dir",
     type=click.Path(
@@ -98,10 +87,22 @@ def vessel(logging_level: str) -> None:
         "in current directory."
     ),
 )
+@click.option(
+    "-m",
+    "--mode",
+    type=click.Choice(["image", "file", "json"]),
+    default="file",
+    show_default=True,
+    help=(
+        "Select comparison mode: 'image' for tar comparison, "
+        "'file' for unpacked filesystem, "
+        "'json' for diffoscope/checksum JSON comparison."
+    ),
+)
 def diff(
     input_files: list[str],
-    compare_level: str,
     data_dir: str,
+    mode: str,
     output_dir: str,
 ) -> None:
     """Unpack container images and compare differences with diffoscope.
@@ -110,8 +111,8 @@ def diff(
     """
     success: bool = DiffCommand(
         input_files,
-        compare_level,
         data_dir,
+        mode,
         output_dir,
     ).execute()
     sys.exit(not success)

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -461,7 +461,7 @@ class DiffCommand:
             image1_path=image1_path,
             image2_path=image2_path,
         )
-        
+
         logger.info("Finished json comparison")
         return True
 

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -105,10 +105,6 @@ class DiffCommand:
             )
             return False
 
-        # default mode if not provided
-        if not self.mode:
-            self.mode = "file"
-
         if all(f.endswith(".json") for f in self.input_files):
             if self.mode != "json":
                 logger.error(

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -56,6 +56,8 @@ logger = getLogger(__name__)
 class DiffCommand:
     """Class that setups up and executes a diff operation."""
 
+    CHECKSUM_METADATA_FILENAME = "checksum_metadata.json"
+
     def __init__(
         self: "DiffCommand",
         input_files: list[str],
@@ -101,34 +103,13 @@ class DiffCommand:
             )
             return False
 
-        # When two inputs provided, determine the mode.
-        if self.input_files[0].endswith(".json") and self.input_files[
-            1
-        ].endswith(".json"):
-            # Accept either order; must be one diffoscope and one checksum metadata file
-            if (
-                "checksum_metadata" in self.input_files[0]
-                or "checksum_metadata" in self.input_files[1]
-            ):
-                diffoscope_json_path = (
-                    self.input_files[0]
-                    if "checksum_metadata" not in self.input_files[0]
-                    else self.input_files[1]
-                )
-                checksum_json_path = (
-                    self.input_files[0]
-                    if "checksum_metadata" in self.input_files[0]
-                    else self.input_files[1]
-                )
-                return self.compare_from_diffoscope_and_checksum_json(
-                    diffoscope_json_path, checksum_json_path
-                )
-            else:
-                logger.error(
-                    "When providing two JSON files, one must be a checksum_metadata.json file."
-                )
-                return False
+        # If two inputs are json files, perform json comparison
+        if len(self.input_files) == 2 and all(
+            f.endswith(".json") for f in self.input_files
+        ):
+            return self.compare_diffoscope_and_checksum_json()
 
+        # Proceed with image comparison
         logger.info("Images to be compared:")
         logger.info("- %s", self.input_files[0])
         logger.info("- %s", self.input_files[1])
@@ -253,33 +234,8 @@ class DiffCommand:
 
         rootfs_path1 = Path(self.unpacked_image_paths[0])
         rootfs_path2 = Path(self.unpacked_image_paths[1])
-        hashed_files1 = hash_folder_contents(rootfs_path1)
-        hashed_files2 = hash_folder_contents(rootfs_path2)
-
-        metadata_path = str(Path(self.output_dir) / "checksum_metadata.json")
-
-        save_checksum_metadata(
-            metadata_path,
-            hashed_files1,
-            hashed_files2,
-            image1_path=str(rootfs_path1),
-            image2_path=str(rootfs_path2),
-        )
-
-        files_summary, checksum_summary = generate_filesummary_and_checksum(
-            diff_list,
-            hashed_files1=hashed_files1,
-            hashed_files2=hashed_files2,
-            image1_path=str(rootfs_path1),
-            image2_path=str(rootfs_path2),
-        )
-        self.write_to_files(
-            unknown,
-            trivial,
-            nontrivial,
-            diff_list,
-            files_summary,
-            checksum_summary,
+        self.process_and_save_results(
+            rootfs_path1, rootfs_path2, diff_list, unknown, trivial, nontrivial
         )
 
         return True
@@ -345,31 +301,8 @@ class DiffCommand:
 
         rootfs_path1 = Path(f"{self.umoci_image_paths[0]}/rootfs")
         rootfs_path2 = Path(f"{self.umoci_image_paths[1]}/rootfs")
-        hashed_files1 = hash_folder_contents(rootfs_path1)
-        hashed_files2 = hash_folder_contents(rootfs_path2)
-        metadata_path = str(Path(self.output_dir) / "checksum_metadata.json")
-        save_checksum_metadata(
-            metadata_path,
-            hashed_files1,
-            hashed_files2,
-            image1_path=str(rootfs_path1),
-            image2_path=str(rootfs_path2),
-        )
-
-        files_summary, checksum_summary = generate_filesummary_and_checksum(
-            diff_list,
-            hashed_files1=hashed_files1,
-            hashed_files2=hashed_files2,
-            image1_path=str(rootfs_path1),
-            image2_path=str(rootfs_path2),
-        )
-        self.write_to_files(
-            unknown,
-            trivial,
-            nontrivial,
-            diff_list,
-            files_summary,
-            checksum_summary,
+        self.process_and_save_results(
+            rootfs_path1, rootfs_path2, diff_list, unknown, trivial, nontrivial
         )
 
         return True
@@ -419,7 +352,7 @@ class DiffCommand:
             files_summary,
             checksum_summary,
         )
-
+        logger.info("Finished json comparison")
         return True
 
     def write_to_files(
@@ -519,3 +452,89 @@ class DiffCommand:
             "w",
         ) as outfile:
             outfile.write(json.dumps(unified_diff_dict, indent=4))
+
+    def compare_diffoscope_and_checksum_json(self):
+        """If two JSON files are provided, and one is named checksum_metadata.json,
+        run the comparison and return the result. Otherwise, log an error and return False.
+        """
+        path1, path2 = self.input_files[0], self.input_files[1]
+        file1, file2 = Path(path1).name, Path(path2).name
+
+        if (
+            file1 != self.CHECKSUM_METADATA_FILENAME
+            and file2 != self.CHECKSUM_METADATA_FILENAME
+        ):
+            logger.error(
+                "When providing two JSON files, one must be a checksum_metadata.json file."
+            )
+            return False
+
+        checksum_json_path = (
+            path1 if file1 == self.CHECKSUM_METADATA_FILENAME else path2
+        )
+        diffoscope_json_path = (
+            path2 if file1 == self.CHECKSUM_METADATA_FILENAME else path1
+        )
+        logger.info("Performing json comparison")
+        return self.compare_from_diffoscope_and_checksum_json(
+            diffoscope_json_path, checksum_json_path
+        )
+
+    def process_and_save_results(
+        self,
+        rootfs_path1: Path,
+        rootfs_path2: Path,
+        diff_list,
+        unknown,
+        trivial,
+        nontrivial,
+    ):
+        """
+        Processes image diff results, generates and saves checksum metadata and summaries,
+        and writes final output files.
+
+        Steps for processing diffoscope output:
+        - Hash the contents of each root filesystem
+        - Save a checksum metadata file with hash results for both images
+        - Generate summary for file and checksum differences
+        - Write summary output to files
+
+        Args:
+            rootfs_path1 (Path): Path to the first image's unpacked root filesystem
+            rootfs_path2 (Path): Path to the second image's unpacked root filesystem
+            diff_list: List of detailed differences returned by diffoscope
+            unknown: Count of unknown differences (from diffoscope parsing)
+            trivial: Count of trivial differences (from diffoscope parsing)
+            nontrivial: Count of nontrivial differences (from diffoscope parsing)
+        """
+        hashed_files1 = hash_folder_contents(rootfs_path1)
+        hashed_files2 = hash_folder_contents(rootfs_path2)
+
+        metadata_path = str(
+            Path(self.output_dir) / self.CHECKSUM_METADATA_FILENAME
+        )
+
+        save_checksum_metadata(
+            metadata_path,
+            hashed_files1,
+            hashed_files2,
+            image1_path=str(rootfs_path1),
+            image2_path=str(rootfs_path2),
+        )
+
+        files_summary, checksum_summary = generate_filesummary_and_checksum(
+            diff_list,
+            hashed_files1=hashed_files1,
+            hashed_files2=hashed_files2,
+            image1_path=str(rootfs_path1),
+            image2_path=str(rootfs_path2),
+        )
+
+        self.write_to_files(
+            unknown,
+            trivial,
+            nontrivial,
+            diff_list,
+            files_summary,
+            checksum_summary,
+        )

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -307,54 +307,6 @@ class DiffCommand:
 
         return True
 
-    def compare_from_diffoscope_and_checksum_json(
-        self: "DiffCommand",
-        diffoscope_json_path: str,
-        checksum_json_path: str,
-    ) -> bool:
-        """
-        Compare results from diffoscope output and checksum metadata.
-
-        Loads a diffoscope JSON output and stored checksum metadata,
-        parses the diffoscope output to extract all diff data, then generates
-        file summary and checksum comparison results using the loaded checksum metadata.
-
-        Args:
-            diffoscope_json_path (str): Path to diffoscope JSON output file.
-            checksum_json_path (str): Path to checksum metadata JSON file.
-
-        Returns:
-            bool: True on success, False on error.
-        """
-        with Path(diffoscope_json_path).open() as f:
-            diffoscope_json = json.load(f)
-
-        unknown, trivial, nontrivial, diff_list = parse_diffoscope_output(
-            diffoscope_json, self.flags
-        )
-
-        hashed_files1, hashed_files2, image1_path, image2_path = (
-            load_checksum_metadata(checksum_json_path)
-        )
-
-        files_summary, checksum_summary = generate_filesummary_and_checksum(
-            diff_list,
-            hashed_files1=hashed_files1,
-            hashed_files2=hashed_files2,
-            image1_path=image1_path,
-            image2_path=image2_path,
-        )
-        self.write_to_files(
-            unknown,
-            trivial,
-            nontrivial,
-            diff_list,
-            files_summary,
-            checksum_summary,
-        )
-        logger.info("Finished json comparison")
-        return True
-
     def write_to_files(
         self: "DiffCommand",
         unknown_failure_count: int,

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -35,6 +35,12 @@ from typing import Any
 
 import yaml
 
+from vessel.utils.checksum import (
+    generate_filesummary_and_checksum,
+    hash_folder_contents,
+    load_checksum_metadata,
+    save_checksum_metadata,
+)
 from vessel.utils.diffoscope import (
     build_diffoscope_command,
     parse_diffoscope_output,
@@ -86,17 +92,44 @@ class DiffCommand:
             return False
 
         if len(self.input_files) == 0:
-            logger.error("No inputs provided. Acceptable values are 1 or 2")
+            logger.error(
+                "No inputs provided. Acceptable values are 2 image paths, or 2 JSON files (diffoscope output and checksum metadata)"
+            )
             return False
-
-        if len(self.input_files) == 1:
-            return self.compare_diffoscope_json()
 
         if len(self.input_files) > 2:
             logger.error(
-                "Too many inputs provided. Acceptable values are 1 or 2",
+                "Too many inputs provided. Acceptable values are 2 image paths, or 2 JSON files (diffoscope output and checksum metadata)."
             )
             return False
+
+        # When two inputs provided, determine the mode.
+        if self.input_files[0].endswith(".json") and self.input_files[
+            1
+        ].endswith(".json"):
+            # Accept either order; must be one diffoscope and one checksum metadata file
+            if (
+                "checksum_metadata" in self.input_files[0]
+                or "checksum_metadata" in self.input_files[1]
+            ):
+                diffoscope_json_path = (
+                    self.input_files[0]
+                    if "checksum_metadata" not in self.input_files[0]
+                    else self.input_files[1]
+                )
+                checksum_json_path = (
+                    self.input_files[0]
+                    if "checksum_metadata" in self.input_files[0]
+                    else self.input_files[1]
+                )
+                return self.compare_from_diffoscope_and_checksum_json(
+                    diffoscope_json_path, checksum_json_path
+                )
+            else:
+                logger.error(
+                    "When providing two JSON files, one must be a checksum_metadata.json file."
+                )
+                return False
 
         logger.info("Images to be compared:")
         logger.info("- %s", self.input_files[0])
@@ -211,27 +244,41 @@ class DiffCommand:
                 logger.exception("Failed: Diff.compare_images")
                 return False
 
-            with Path(
-                self.output_dir + "/" + self.diffoscope_output_file_name,
-            ).open() as raw_diff_file:
-                diffoscope_json = json.load(raw_diff_file)
+        with Path(
+            self.output_dir + "/" + self.diffoscope_output_file_name,
+        ).open() as raw_diff_file:
+            diffoscope_json = json.load(raw_diff_file)
 
-        (
-            unknown_failures_count,
-            trivial_failures_count,
-            nontrivial_failures_count,
+        unknown, trivial, nontrivial, diff_list = parse_diffoscope_output(
+            diffoscope_json, self.flags
+        )
+
+        rootfs_path1 = Path(self.unpacked_image_paths[0])
+        rootfs_path2 = Path(self.unpacked_image_paths[1])
+        hashed_files1 = hash_folder_contents(rootfs_path1)
+        hashed_files2 = hash_folder_contents(rootfs_path2)
+
+        metadata_path = str(Path(self.output_dir) / "checksum_metadata.json")
+
+        save_checksum_metadata(
+            metadata_path,
+            hashed_files1,
+            hashed_files2,
+            image1_path=str(rootfs_path1),
+            image2_path=str(rootfs_path2),
+        )
+
+        files_summary, checksum_summary = generate_filesummary_and_checksum(
             diff_list,
-            files_summary,
-            checksum_summary,
-        ) = parse_diffoscope_output(
-            diffoscope_json,
-            self.flags,
-            file_checksum=self.file_checksum,
+            hashed_files1=hashed_files1,
+            hashed_files2=hashed_files2,
+            image1_path=str(rootfs_path1),
+            image2_path=str(rootfs_path2),
         )
         self.write_to_files(
-            unknown_failures_count,
-            trivial_failures_count,
-            nontrivial_failures_count,
+            unknown,
+            trivial,
+            nontrivial,
             diff_list,
             files_summary,
             checksum_summary,
@@ -294,22 +341,34 @@ class DiffCommand:
         ).open() as raw_diff_file:
             diffoscope_json = json.load(raw_diff_file)
 
-        (
-            unknown_failures_count,
-            trivial_failures_count,
-            nontrivial_failures_count,
+        unknown, trivial, nontrivial, diff_list = parse_diffoscope_output(
+            diffoscope_json, self.flags
+        )
+
+        rootfs_path1 = Path(f"{self.umoci_image_paths[0]}/rootfs")
+        rootfs_path2 = Path(f"{self.umoci_image_paths[1]}/rootfs")
+        hashed_files1 = hash_folder_contents(rootfs_path1)
+        hashed_files2 = hash_folder_contents(rootfs_path2)
+        metadata_path = str(Path(self.output_dir) / "checksum_metadata.json")
+        save_checksum_metadata(
+            metadata_path,
+            hashed_files1,
+            hashed_files2,
+            image1_path=str(rootfs_path1),
+            image2_path=str(rootfs_path2),
+        )
+
+        files_summary, checksum_summary = generate_filesummary_and_checksum(
             diff_list,
-            files_summary,
-            checksum_summary,
-        ) = parse_diffoscope_output(
-            diffoscope_json,
-            self.flags,
-            file_checksum=self.file_checksum,
+            hashed_files1=hashed_files1,
+            hashed_files2=hashed_files2,
+            image1_path=str(rootfs_path1),
+            image2_path=str(rootfs_path2),
         )
         self.write_to_files(
-            unknown_failures_count,
-            trivial_failures_count,
-            nontrivial_failures_count,
+            unknown,
+            trivial,
+            nontrivial,
             diff_list,
             files_summary,
             checksum_summary,
@@ -317,31 +376,47 @@ class DiffCommand:
 
         return True
 
-    def compare_diffoscope_json(self: "DiffCommand") -> bool:
-        """Parses diffoscope json when file provided directly.
+    def compare_from_diffoscope_and_checksum_json(
+        self: "DiffCommand",
+        diffoscope_json_path: str,
+        checksum_json_path: str,
+    ) -> bool:
+        """
+        Compare results from diffoscope output and checksum metadata.
+
+        Loads a diffoscope JSON output and stored checksum metadata,
+        parses the diffoscope output to extract all diff data, then generates
+        file summary and checksum comparison results using the loaded checksum metadata.
+
+        Args:
+            diffoscope_json_path (str): Path to diffoscope JSON output file.
+            checksum_json_path (str): Path to checksum metadata JSON file.
 
         Returns:
-            True on success
+            bool: True on success, False on error.
         """
-        with Path(self.input_files[0]).open() as raw_diff_file:
-            diffoscope_json = json.load(raw_diff_file)
+        with Path(diffoscope_json_path).open() as f:
+            diffoscope_json = json.load(f)
 
-        (
-            unknown_failures_count,
-            trivial_failures_count,
-            nontrivial_failures_count,
+        unknown, trivial, nontrivial, diff_list = parse_diffoscope_output(
+            diffoscope_json, self.flags
+        )
+
+        hashed_files1, hashed_files2, image1_path, image2_path = (
+            load_checksum_metadata(checksum_json_path)
+        )
+
+        files_summary, checksum_summary = generate_filesummary_and_checksum(
             diff_list,
-            files_summary,
-            checksum_summary,
-        ) = parse_diffoscope_output(
-            diffoscope_json,
-            self.flags,
-            file_checksum=self.file_checksum,
+            hashed_files1=hashed_files1,
+            hashed_files2=hashed_files2,
+            image1_path=image1_path,
+            image2_path=image2_path,
         )
         self.write_to_files(
-            unknown_failures_count,
-            trivial_failures_count,
-            nontrivial_failures_count,
+            unknown,
+            trivial,
+            nontrivial,
             diff_list,
             files_summary,
             checksum_summary,

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -57,12 +57,15 @@ class DiffCommand:
     """Class that setups up and executes a diff operation."""
 
     CHECKSUM_METADATA_FILENAME = "checksum_metadata.json"
+    DIFFOSCOPE_OUTPUT_FILENAME = "diffoscope_output.json"
+    SUMMARY_OUTPUT_FILENAME = "summary.json"
+    UNIFIED_DIFF_OUTPUT_FILENAME = "unified_diffs.json"
 
     def __init__(
         self: "DiffCommand",
         input_files: list[str],
-        compare_level: str,
         data_dir: str,
+        mode: str,
         output_dir: str,
     ) -> None:
         """Initializer for a diff operation.
@@ -71,16 +74,13 @@ class DiffCommand:
         """
         self.flags: list[Flag] = []
         self.input_files: list[str] = input_files
-        self.compare_level: str = compare_level
+        self.mode: str = mode
         self.data_dir: str = data_dir
         self.output_dir: str = output_dir
         self.temp_dir: tempfile.TemporaryDirectory[str] | None = None
         self.image_uris: list[ImageURI] = []
-        self.unpacked_image_paths: list[str] = []
-        self.umoci_image_paths: list[str] = []
-        self.diffoscope_output_file_name = "diffoscope_output.json"
-        self.summary_output_file_name = "summary.json"
-        self.unified_diff_output_file_name = "unified_diffs.json"
+        self.oci_image_paths: list[str] = []
+        self.oci_runtime_paths: list[str] = []
 
     def execute(self: "DiffCommand") -> bool:
         """Executes a diff operation.
@@ -91,25 +91,34 @@ class DiffCommand:
         if not self._setup():
             return False
 
-        if len(self.input_files) == 0:
+        if len(self.input_files) < 2:
             logger.error(
-                "No inputs provided. Acceptable values are 2 image paths, or 2 JSON files (diffoscope output and checksum metadata)"
+                "At least 2 inputs required. Acceptable values are 2 image paths, "
+                "or 2 JSON files (diffoscope output and checksum metadata)"
             )
             return False
 
         if len(self.input_files) > 2:
             logger.error(
-                "Too many inputs provided. Acceptable values are 2 image paths, or 2 JSON files (diffoscope output and checksum metadata)."
+                "Too many inputs provided. Acceptable values are 2 image paths, "
+                "or 2 JSON files (diffoscope output and checksum metadata)"
             )
             return False
 
-        # If two inputs are json files, perform json comparison
-        if len(self.input_files) == 2 and all(
-            f.endswith(".json") for f in self.input_files
-        ):
-            return self.compare_diffoscope_and_checksum_json()
+        # default mode if not provided
+        if not self.mode:
+            self.mode = "file"
 
-        # Proceed with image comparison
+        if all(f.endswith(".json") for f in self.input_files):
+            if self.mode != "json":
+                logger.error(
+                    "Two JSON files detected but mode is not 'json' "
+                    "Please rerun with -m json"
+                )
+                return False
+            return self._compare_diffoscope_and_checksum_json()
+
+        # Image or file mode
         logger.info("Images to be compared:")
         logger.info("- %s", self.input_files[0])
         logger.info("- %s", self.input_files[1])
@@ -117,20 +126,20 @@ class DiffCommand:
         if not self._unpack_images():
             return False
 
-        if self.compare_level == "image":
+        if self.mode == "image":
             return self._compare_images()
 
-        if get_manifest_digest(
-            self.unpacked_image_paths[0],
-        ) == get_manifest_digest(self.unpacked_image_paths[1]):
+        if get_manifest_digest(self.oci_image_paths[0]) == get_manifest_digest(
+            self.oci_image_paths[1]
+        ):
             logger.info("All layers are identical")
-            self.write_to_files(0, 0, 0, [], [], {})
+            self._write_to_files(0, 0, 0, [], [], {})
             return True
 
-        if self.compare_level == "file":
+        if self.mode == "file":
             return self._compare_files()
 
-        logger.error("Invalid compare level selected.")
+        logger.error("Invalid mode selected. Choose from: image, file, json")
         return False
 
     def _setup(self: "DiffCommand") -> bool:
@@ -193,7 +202,7 @@ class DiffCommand:
             self.image_uris[0].output_identifier = f"{self.image_uris[0].output_identifier}_0"  # noqa: E501 # fmt: skip
             self.image_uris[1].output_identifier = f"{self.image_uris[1].output_identifier}_1"  # noqa: E501 # fmt: skip
 
-        self.unpacked_image_paths = [
+        self.oci_image_paths = [
             skopeo_copy(image_path, self.data_dir)
             for image_path in self.image_uris
         ]
@@ -208,10 +217,10 @@ class DiffCommand:
         """
         cmd = build_diffoscope_command(
             self.output_dir,
-            self.diffoscope_output_file_name,
-            self.unpacked_image_paths[0],
-            self.unpacked_image_paths[1],
-            self.compare_level,
+            self.DIFFOSCOPE_OUTPUT_FILENAME,
+            self.oci_image_paths[0],
+            self.oci_image_paths[1],
+            self.mode,
         )
         try:
             subprocess.run(cmd, check=True)  # noqa: S603
@@ -224,7 +233,7 @@ class DiffCommand:
                 return False
 
         with Path(
-            self.output_dir + "/" + self.diffoscope_output_file_name,
+            self.output_dir + "/" + self.DIFFOSCOPE_OUTPUT_FILENAME,
         ).open() as raw_diff_file:
             diffoscope_json = json.load(raw_diff_file)
 
@@ -232,10 +241,10 @@ class DiffCommand:
             diffoscope_json, self.flags
         )
 
-        rootfs_path1 = Path(self.unpacked_image_paths[0])
-        rootfs_path2 = Path(self.unpacked_image_paths[1])
-        self.process_and_save_results(
-            rootfs_path1, rootfs_path2, diff_list, unknown, trivial, nontrivial
+        image1_path = Path(self.oci_image_paths[0])
+        image2_path = Path(self.oci_image_paths[1])
+        self._process_and_save_results(
+            image1_path, image2_path, diff_list, unknown, trivial, nontrivial
         )
 
         return True
@@ -250,14 +259,14 @@ class DiffCommand:
             True on success, else False
         """
         for unpack_path, uri in zip(
-            self.unpacked_image_paths,
+            self.oci_image_paths,
             self.image_uris,
             strict=True,
         ):
             umoci_output_path = (
                 f"{self.data_dir}/umoci-unpack-{uri.output_identifier}"
             )
-            self.umoci_image_paths.append(umoci_output_path)
+            self.oci_runtime_paths.append(umoci_output_path)
 
             try:
                 subprocess.run(
@@ -275,10 +284,10 @@ class DiffCommand:
 
         cmd = build_diffoscope_command(
             self.output_dir,
-            self.diffoscope_output_file_name,
-            f"{self.umoci_image_paths[0]}/rootfs",
-            f"{self.umoci_image_paths[1]}/rootfs",
-            self.compare_level,
+            self.DIFFOSCOPE_OUTPUT_FILENAME,
+            f"{self.oci_runtime_paths[0]}/rootfs",
+            f"{self.oci_runtime_paths[1]}/rootfs",
+            self.mode,
         )
         try:
             subprocess.run(cmd, check=True)  # noqa: S603
@@ -291,7 +300,7 @@ class DiffCommand:
                 return False
 
         with Path(
-            self.output_dir + "/" + self.diffoscope_output_file_name,
+            self.output_dir + "/" + self.DIFFOSCOPE_OUTPUT_FILENAME,
         ).open() as raw_diff_file:
             diffoscope_json = json.load(raw_diff_file)
 
@@ -299,15 +308,15 @@ class DiffCommand:
             diffoscope_json, self.flags
         )
 
-        rootfs_path1 = Path(f"{self.umoci_image_paths[0]}/rootfs")
-        rootfs_path2 = Path(f"{self.umoci_image_paths[1]}/rootfs")
-        self.process_and_save_results(
-            rootfs_path1, rootfs_path2, diff_list, unknown, trivial, nontrivial
+        image1_path = Path(f"{self.oci_runtime_paths[0]}/rootfs")
+        image2_path = Path(f"{self.oci_runtime_paths[1]}/rootfs")
+        self._process_and_save_results(
+            image1_path, image2_path, diff_list, unknown, trivial, nontrivial
         )
 
         return True
 
-    def write_to_files(
+    def _write_to_files(
         self: "DiffCommand",
         unknown_failure_count: int,
         trivial_failure_count: int,
@@ -395,17 +404,17 @@ class DiffCommand:
 
         output_dir = self.output_dir + "/"
 
-        with Path(str(output_dir) + self.summary_output_file_name).open(
+        with Path(str(output_dir) + self.SUMMARY_OUTPUT_FILENAME).open(
             "w",
         ) as outfile:
             outfile.write(json.dumps(summary_json, indent=4))
 
-        with Path(str(output_dir) + self.unified_diff_output_file_name).open(
+        with Path(str(output_dir) + self.UNIFIED_DIFF_OUTPUT_FILENAME).open(
             "w",
         ) as outfile:
             outfile.write(json.dumps(unified_diff_dict, indent=4))
 
-    def compare_diffoscope_and_checksum_json(self) -> bool:
+    def _compare_diffoscope_and_checksum_json(self) -> bool:
         """
         If two JSON files are provided, and one is named checksum_metadata.json,
         run the comparison and return the result. Otherwise, log an error and return False.
@@ -454,7 +463,7 @@ class DiffCommand:
             image2_path=image2_path,
         )
 
-        self.write_to_files(
+        self._write_to_files(
             unknown,
             trivial,
             nontrivial,
@@ -465,35 +474,23 @@ class DiffCommand:
         logger.info("Finished json comparison")
         return True
 
-    def process_and_save_results(
+    def _hash_and_save_checksum_metadata(
         self,
-        rootfs_path1: Path,
-        rootfs_path2: Path,
-        diff_list,
-        unknown,
-        trivial,
-        nontrivial,
-    ):
-        """
-        Processes image diff results, generates and saves checksum metadata and summaries,
-        and writes final output files.
-
-        Steps for processing diffoscope output:
-        - Hash the contents of each root filesystem
-        - Save a checksum metadata file with hash results for both images
-        - Generate summary for file and checksum differences
-        - Write summary output to files
+        image1_path: Path,
+        image2_path: Path,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Hash both filesystems and write checksum metadata JSON
 
         Args:
-            rootfs_path1 (Path): Path to the first image's unpacked root filesystem
-            rootfs_path2 (Path): Path to the second image's unpacked root filesystem
-            diff_list: List of detailed differences returned by diffoscope
-            unknown: Count of unknown differences (from diffoscope parsing)
-            trivial: Count of trivial differences (from diffoscope parsing)
-            nontrivial: Count of nontrivial differences (from diffoscope parsing)
+            image1_path: Path to first image filesystem
+            image2_path: Path to second image filesystem
+
+        Returns:
+            A tuple (hashed_files1, hashed_files2), where each element is a mapping
+            of file path to hashed file
         """
-        hashed_files1 = hash_folder_contents(rootfs_path1)
-        hashed_files2 = hash_folder_contents(rootfs_path2)
+        hashed_files1 = hash_folder_contents(image1_path)
+        hashed_files2 = hash_folder_contents(image2_path)
 
         metadata_path = str(
             Path(self.output_dir) / self.CHECKSUM_METADATA_FILENAME
@@ -503,23 +500,82 @@ class DiffCommand:
             metadata_path,
             hashed_files1,
             hashed_files2,
-            image1_path=str(rootfs_path1),
-            image2_path=str(rootfs_path2),
+            image1_path=str(image1_path),
+            image2_path=str(image2_path),
         )
+        return hashed_files1, hashed_files2
 
+    def _summarize_and_write_outputs(
+        self,
+        diff_list: list[dict[str, Any]],
+        unknown_failure_count: int,
+        trivial_failure_count: int,
+        nontrivial_failure_count: int,
+        hashed_files1: dict[str, Any],
+        hashed_files2: dict[str, Any],
+        image1_path: str,
+        image2_path: str,
+    ) -> None:
+        """Generate checksum summaries and write output
+
+        Args:
+            diff_list: Diffs returned by diffoscope parsing
+            unknown_failure_count: Number of unknown differences
+            trivial_failure_count: Number of trivial differences
+            nontrivial_failure_count: Number of nontrivial differences
+            hashed_files1: Hash map for image 1 (path to metadata)
+            hashed_files2: Hash map for image 2 (path to metadata)
+            image1_path: Path to first image filesystem
+            image2_path: Path to second image filesystem
+        """
         files_summary, checksum_summary = generate_filesummary_and_checksum(
             diff_list,
             hashed_files1=hashed_files1,
             hashed_files2=hashed_files2,
-            image1_path=str(rootfs_path1),
-            image2_path=str(rootfs_path2),
+            image1_path=image1_path,
+            image2_path=image2_path,
         )
 
-        self.write_to_files(
-            unknown,
-            trivial,
-            nontrivial,
-            diff_list,
-            files_summary,
-            checksum_summary,
+        self._write_to_files(
+            unknown_failure_count=unknown_failure_count,
+            trivial_failure_count=trivial_failure_count,
+            nontrivial_failure_count=nontrivial_failure_count,
+            diffs=diff_list,
+            files_summary=files_summary,
+            checksum_summary=checksum_summary,
+        )
+
+    def _process_and_save_results(
+        self,
+        image1_path: Path,
+        image2_path: Path,
+        diff_list: list[dict[str, Any]],
+        unknown_failure_count: int,
+        trivial_failure_count: int,
+        nontrivial_failure_count: int,
+    ) -> None:
+        """
+        Hash image directories, save checksum metadata, summarize, and write outputs
+
+        Args:
+            image1_path: Path to first image filesystem
+            image2_path: Path to second image filesystem
+            diff_list: List of detailed differences returned by diffoscope parsing
+            unknown_failure_count: Count of unknown differences
+            trivial_failure_count: Count of trivial differences
+            nontrivial_failure_count: Count of nontrivial differences
+        """
+        hashed_files1, hashed_files2 = self._hash_and_save_checksum_metadata(
+            image1_path, image2_path
+        )
+
+        self._summarize_and_write_outputs(
+            diff_list=diff_list,
+            unknown_failure_count=unknown_failure_count,
+            trivial_failure_count=trivial_failure_count,
+            nontrivial_failure_count=nontrivial_failure_count,
+            hashed_files1=hashed_files1,
+            hashed_files2=hashed_files2,
+            image1_path=str(image1_path),
+            image2_path=str(image2_path),
         )

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -39,7 +39,7 @@ from vessel.utils.checksum import (
     generate_filesummary_and_checksum,
     hash_folder_contents,
     load_checksum_metadata,
-    save_checksum_metadata,
+    write_checksum_metadata,
 )
 from vessel.utils.diffoscope import (
     build_diffoscope_command,
@@ -451,26 +451,21 @@ class DiffCommand:
             filetype_lookup2=filetype_lookup2,
         )
 
-        files_summary, checksum_summary = generate_filesummary_and_checksum(
-            diff_list,
+        self._summarize_and_write_outputs(
+            diff_list=diff_list,
+            unknown_failure_count=unknown,
+            trivial_failure_count=trivial,
+            nontrivial_failure_count=nontrivial,
             hashed_files1=hashed_files1,
             hashed_files2=hashed_files2,
             image1_path=image1_path,
             image2_path=image2_path,
         )
-
-        self._write_to_files(
-            unknown,
-            trivial,
-            nontrivial,
-            diff_list,
-            files_summary,
-            checksum_summary,
-        )
+        
         logger.info("Finished json comparison")
         return True
 
-    def _hash_and_save_checksum_metadata(
+    def _hash_and_write_checksum_metadata(
         self,
         image1_path: Path,
         image2_path: Path,
@@ -492,7 +487,7 @@ class DiffCommand:
             Path(self.output_dir) / self.CHECKSUM_METADATA_FILENAME
         )
 
-        save_checksum_metadata(
+        write_checksum_metadata(
             metadata_path,
             hashed_files1,
             hashed_files2,
@@ -561,7 +556,7 @@ class DiffCommand:
             trivial_failure_count: Count of trivial differences
             nontrivial_failure_count: Count of nontrivial differences
         """
-        hashed_files1, hashed_files2 = self._hash_and_save_checksum_metadata(
+        hashed_files1, hashed_files2 = self._hash_and_write_checksum_metadata(
             image1_path, image2_path
         )
 

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -453,8 +453,9 @@ class DiffCommand:
         ) as outfile:
             outfile.write(json.dumps(unified_diff_dict, indent=4))
 
-    def compare_diffoscope_and_checksum_json(self):
-        """If two JSON files are provided, and one is named checksum_metadata.json,
+    def compare_diffoscope_and_checksum_json(self) -> bool:
+        """
+        If two JSON files are provided, and one is named checksum_metadata.json,
         run the comparison and return the result. Otherwise, log an error and return False.
         """
         path1, path2 = self.input_files[0], self.input_files[1]
@@ -468,17 +469,49 @@ class DiffCommand:
                 "When providing two JSON files, one must be a checksum_metadata.json file."
             )
             return False
-
+        logger.info("Started json comparison")
         checksum_json_path = (
             path1 if file1 == self.CHECKSUM_METADATA_FILENAME else path2
         )
         diffoscope_json_path = (
             path2 if file1 == self.CHECKSUM_METADATA_FILENAME else path1
         )
-        logger.info("Performing json comparison")
-        return self.compare_from_diffoscope_and_checksum_json(
-            diffoscope_json_path, checksum_json_path
+
+        # Load checksum metadata first so we can pass filetype lookups to the parser
+        hashed_files1, hashed_files2, image1_path, image2_path = (
+            load_checksum_metadata(checksum_json_path)
         )
+        filetype_lookup1 = {k: v.filetype for k, v in hashed_files1.items()}
+        filetype_lookup2 = {k: v.filetype for k, v in hashed_files2.items()}
+
+        with Path(diffoscope_json_path).open() as f:
+            diffoscope_json = json.load(f)
+
+        unknown, trivial, nontrivial, diff_list = parse_diffoscope_output(
+            diffoscope_json,
+            self.flags,
+            filetype_lookup1=filetype_lookup1,
+            filetype_lookup2=filetype_lookup2,
+        )
+
+        files_summary, checksum_summary = generate_filesummary_and_checksum(
+            diff_list,
+            hashed_files1=hashed_files1,
+            hashed_files2=hashed_files2,
+            image1_path=image1_path,
+            image2_path=image2_path,
+        )
+
+        self.write_to_files(
+            unknown,
+            trivial,
+            nontrivial,
+            diff_list,
+            files_summary,
+            checksum_summary,
+        )
+        logger.info("Finished json comparison")
+        return True
 
     def process_and_save_results(
         self,

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -62,7 +62,6 @@ class DiffCommand:
         compare_level: str,
         data_dir: str,
         output_dir: str,
-        file_checksum: bool,
     ) -> None:
         """Initializer for a diff operation.
 
@@ -73,7 +72,6 @@ class DiffCommand:
         self.compare_level: str = compare_level
         self.data_dir: str = data_dir
         self.output_dir: str = output_dir
-        self.file_checksum: bool = file_checksum
         self.temp_dir: tempfile.TemporaryDirectory[str] | None = None
         self.image_uris: list[ImageURI] = []
         self.unpacked_image_paths: list[str] = []

--- a/vessel/utils/checksum.py
+++ b/vessel/utils/checksum.py
@@ -125,7 +125,7 @@ def make_checksum_dict(
     }
 
 
-def save_checksum_metadata(
+def write_checksum_metadata(
     path, hashed_files1, hashed_files2, image1_path=None, image2_path=None
 ):
     data = {

--- a/vessel/utils/checksum.py
+++ b/vessel/utils/checksum.py
@@ -26,11 +26,14 @@
 """Utility checksum functions."""
 
 import hashlib
+import json
 from logging import getLogger
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import magic
+
+from vessel.utils.diffoscope import build_diff_lookup
 
 logger = getLogger(__name__)
 
@@ -54,6 +57,29 @@ class FileHash:
         self.path = path
         self.filetype = filetype
         self.hash = hash
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialize FileHash to dict"""
+        return {
+            "filetype": self.filetype,
+            "hash": self.hash,
+        }
+
+    @staticmethod
+    def from_dict(path: str, dictionary: dict[str, str]) -> "FileHash":
+        """
+        Deserialize a FileHash object from a dictionary.
+
+        Args:
+            path (str): The path of the file (used as the key in the metadata dict).
+            dictionary (dict): Dictionary with keys 'filetype' and 'hash'.
+
+        Returns:
+            FileHash: New FileHash object created from the dictionary.
+        """
+        return FileHash(
+            path=path, filetype=dictionary["filetype"], hash=dictionary["hash"]
+        )
 
 
 def hash_folder_contents(folder_path: Path) -> dict[str, FileHash]:
@@ -97,6 +123,33 @@ def make_checksum_dict(
         "filetype1": filetype1,
         "filetype2": filetype2,
     }
+
+
+def save_checksum_metadata(
+    path, hashed_files1, hashed_files2, image1_path=None, image2_path=None
+):
+    data = {
+        "image1_path": str(image1_path) if image1_path is not None else "",
+        "image2_path": str(image2_path) if image2_path is not None else "",
+        "hashed_files1": {k: v.to_dict() for k, v in hashed_files1.items()},
+        "hashed_files2": {k: v.to_dict() for k, v in hashed_files2.items()},
+    }
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_checksum_metadata(path):
+    with open(path, "r") as f:
+        data = json.load(f)
+    hashed_files1 = {
+        k: FileHash.from_dict(k, v) for k, v in data["hashed_files1"].items()
+    }
+    hashed_files2 = {
+        k: FileHash.from_dict(k, v) for k, v in data["hashed_files2"].items()
+    }
+    image1 = data.get("image1_path", "")
+    image2 = data.get("image2_path", "")
+    return hashed_files1, hashed_files2, image1, image2
 
 
 def summarize_checksums(
@@ -331,3 +384,91 @@ def classify_checksum_mismatches(
             )
 
     return trivial_diffs, nontrivial_diffs
+
+
+def generate_filesummary_and_checksum(
+    diff_list: list[dict],
+    rootfs_path1: Optional[Path] = None,
+    rootfs_path2: Optional[Path] = None,
+    hashed_files1: Optional[dict[str, "FileHash"]] = None,
+    hashed_files2: Optional[dict[str, "FileHash"]] = None,
+    image1_path: Optional[str] = None,
+    image2_path: Optional[str] = None,
+) -> tuple[list[dict], dict]:
+    """Generate file summary and checksum summary
+
+    Build diff_lookup table from the diff results and compute
+    checksums and file differences between two image rootfs directories or
+    two precomputed hashed_files dictionaries
+
+    Args:
+        diff_list: diffs from parsed diffoscope output.
+        rootfs_path1: (Optional) Path to first image rootfs.
+        rootfs_path2: (Optional) Path to second image rootfs.
+        hashed_files1: (Optional) Precomputed hashes for files in rootfs_path1.
+        hashed_files2: (Optional) Precomputed hashes for files in rootfs_path2.
+        image1: (Optional) image1 full path loaded from metadata.
+        image2: (Optional) image2 full path loaded from metadata.
+
+    Returns:
+        files_summary: List containing file and checksum comparison details.
+        checksum_summary: Dict summarizing checksum matches, mismatches, and unique files.
+    """
+    # If hashes not supplied, compute them from rootfs
+    if hashed_files1 is None:
+        if rootfs_path1 is None:
+            raise ValueError(
+                "rootfs_path1 cannot be None when hashed_files1 is not provided"
+            )
+        hashed_files1 = hash_folder_contents(rootfs_path1)
+    if hashed_files2 is None:
+        if rootfs_path2 is None:
+            raise ValueError(
+                "rootfs_path2 cannot be None when hashed_files2 is not provided"
+            )
+        hashed_files2 = hash_folder_contents(rootfs_path2)
+
+    # Make sure image1_path and image2_path were loaded from the metadata file as well
+    if rootfs_path1 is not None and rootfs_path2 is not None:
+        image1_path = str(rootfs_path1)
+        image2_path = str(rootfs_path2)
+    elif image1_path is not None and image2_path is not None:
+        image1_path = image1_path
+        image2_path = image2_path
+    else:
+        raise ValueError(
+            "When passing precomputed hashes, image1 path and image2 path must be provided"
+        )
+
+    diff_lookup = build_diff_lookup(diff_list)
+    if rootfs_path1 is None or rootfs_path2 is None:
+        checksum_summary = summarize_checksums(
+            diff_lookup,
+            Path(image1_path),
+            hashed_files1,
+            Path(image2_path),
+            hashed_files2,
+        )
+    else:
+        checksum_summary = summarize_checksums(
+            diff_lookup,
+            rootfs_path1,
+            hashed_files1,
+            rootfs_path2,
+            hashed_files2,
+        )
+
+    trivial_diffs, nontrivial_diffs = classify_checksum_mismatches(
+        checksum_summary, diff_lookup, hashed_files1, hashed_files2
+    )
+    files_summary = [
+        {
+            "image1": checksum_summary["image1"],
+            "image2": checksum_summary["image2"],
+            "only_in_image1": checksum_summary["only_in_image1"],
+            "only_in_image2": checksum_summary["only_in_image2"],
+            "trivial_checksum_different_files": trivial_diffs,
+            "nontrivial_checksum_different_files": nontrivial_diffs,
+        }
+    ]
+    return files_summary, checksum_summary

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -178,11 +178,11 @@ def parse_diffoscope_output(
         # Handles case where diff is found with a command such as stat {}.
         # Diffoscope lists the source of the diff as the command that it used to get
         # the diff, so the file path must be grabbed from the parent.
-        src1_raw = str(current_detail.get("source1", ""))
-        src2_raw = str(current_detail.get("source2", ""))
+        source1_raw = str(current_detail.get("source1", ""))
+        source2_raw = str(current_detail.get("source2", ""))
 
-        if not _is_path(src1_raw) or not _is_path(src2_raw):
-            diff.command = src1_raw
+        if not _is_path(source1_raw) or not _is_path(source1_raw):
+            diff.command = source2_raw
             diff.source1 = parent_source1
             diff.source2 = parent_source2
 

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -181,8 +181,8 @@ def parse_diffoscope_output(
         source1_raw = str(current_detail.get("source1", ""))
         source2_raw = str(current_detail.get("source2", ""))
 
-        if not _is_path(source1_raw) or not _is_path(source1_raw):
-            diff.command = source2_raw
+        if not _is_path(source1_raw) or not _is_path(source2_raw):
+            diff.command = source1_raw
             diff.source1 = parent_source1
             diff.source2 = parent_source2
 

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -27,15 +27,10 @@
 
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import magic
 
-from vessel.utils.checksum import (
-    classify_checksum_mismatches,
-    hash_folder_contents,
-    summarize_checksums,
-)
 from vessel.utils.flag import Flag
 from vessel.utils.unified_diff import (
     Diff,
@@ -124,12 +119,8 @@ def parse_diffoscope_output(
     parent_source1: str = "",
     parent_source2: str = "",
     parent_comments: list[str] | None = None,
-    files_summary: Optional[list[dict[str, Any]]] = None,
-    file_checksum: bool = False,
-) -> tuple[
-    int, int, int, list[dict[Any, Any]], list[dict[str, Any]], dict[Any, Any]
-]:
-    """Recursively parses diffoscope json output.
+) -> tuple[int, int, int, list[dict[Any, Any]]]:
+    """Recursively parses diffoscope json output
 
     Recursively navigates through entirety of diffoscope json output
     parsing the diffs and returning a JSON object with failures
@@ -137,7 +128,7 @@ def parse_diffoscope_output(
 
     Args:
         current_detail: Dict object containing an instance of a diff
-                        from diffoscope output.
+                        from diffoscope output
         flags: List of all flags contained within
                 `config/diff_config.yaml`
         parent_source1: Source of diff of parent1 to substitute into
@@ -149,21 +140,14 @@ def parse_diffoscope_output(
         parent_comments: List of comments from the parent object in diffoscope
                         as sometimes the comments that relate to a child are in
                         the parent detail
-        files_summary: File analysis of trivial/nontrivial failure
-        file_checksum: Whether detail of checksum matches and mismatch
-                       should be included in the summary.json
-
     Returns:
         Count of unknown failures, count of flagged failures, diff list,
-        and overall file analysis summary and checksum comparison summary.
+        and overall file analysis summary
     """
     trivial_failures_count = 0
     nontrivial_failures_count = 0
     unknown_failures_count = 0
     diff_list = []
-
-    if files_summary is None:
-        files_summary = []
 
     if current_detail["unified_diff"] is not None:
         temp_comments = []
@@ -362,71 +346,14 @@ def parse_diffoscope_output(
                 current_detail["source1"],
                 current_detail["source2"],
                 current_detail.get("comments"),
-                files_summary,
-                file_checksum=file_checksum,
             )
             unknown_failures_count += child_return[0]
             trivial_failures_count += child_return[1]
             nontrivial_failures_count += child_return[2]
             diff_list.extend(child_return[3])
-
-    checksum_summary = {}
-    # Only generate the final summary when it's top-level call (end of recursion)
-    if (
-        parent_source1 == ""
-        and parent_source2 == ""
-        and parent_comments is None
-    ):
-        # Path to rootfs of unpacked image, ex: image1/rootfs
-        rootfs_path1 = Path(current_detail["source1"])
-        rootfs_path2 = Path(current_detail["source2"])
-        hashed_files1 = hash_folder_contents(rootfs_path1)
-        hashed_files2 = hash_folder_contents(rootfs_path2)
-        diff_lookup = build_diff_lookup(diff_list)
-        checksum_summary = summarize_checksums(
-            diff_lookup,
-            rootfs_path1,
-            hashed_files1,
-            rootfs_path2,
-            hashed_files2,
-        )
-        trivial_diffs, nontrivial_diffs = classify_checksum_mismatches(
-            checksum_summary, diff_lookup, hashed_files1, hashed_files2
-        )
-        files_summary.append(
-            {
-                "image1": checksum_summary["image1"],
-                "image2": checksum_summary["image2"],
-                "only_in_image1": checksum_summary["only_in_image1"],
-                "only_in_image2": checksum_summary["only_in_image2"],
-                "trivial_checksum_different_files": trivial_diffs,
-                "nontrivial_checksum_different_files": nontrivial_diffs,
-            }
-        )
-        if file_checksum:
-            files_summary.append(
-                {
-                    "checksum_mismatches": checksum_summary[
-                        "checksum_mismatches"
-                    ],
-                    "checksum_matches": checksum_summary["checksum_matches"],
-                }
-            )
-
-        return (
-            unknown_failures_count,
-            trivial_failures_count,
-            nontrivial_failures_count,
-            diff_list,
-            files_summary,
-            checksum_summary,
-        )
-
     return (
         unknown_failures_count,
         trivial_failures_count,
         nontrivial_failures_count,
         diff_list,
-        files_summary,
-        checksum_summary,
     )

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -26,7 +26,6 @@
 """Utility Diffoscope functions."""
 
 import re
-from logging import getLogger
 from pathlib import Path
 from typing import Any
 
@@ -40,15 +39,13 @@ from vessel.utils.unified_diff import (
     make_failure_dict,
 )
 
-logger = getLogger(__name__)
-
 
 def build_diffoscope_command(
     output_dir_path: str,
     output_file_name: str,
     path1: str,
     path2: str,
-    compare_level: str,
+    mode: str,
 ) -> list[str]:
     """Generates a command list to execute diffoscope.
 
@@ -58,7 +55,7 @@ def build_diffoscope_command(
         output_file_name: File name that will be used for diffoscope output
         path1: The first path to compare
         path2: The second path to compare
-        compare_level: Diff mode (image or file)
+        mode: Comparison mode ("image" or "file")
 
     Returns:
         Commands list to execute diffoscope.
@@ -66,7 +63,7 @@ def build_diffoscope_command(
     cmd = ["diffoscope"]
     cmd.extend(["--json", f"{output_dir_path}/{output_file_name}"])
 
-    if compare_level == "file":
+    if mode == "file":
         cmd.append("--new-file")
 
     cmd.extend([path1, path2])
@@ -116,9 +113,9 @@ def build_diff_lookup(
     return lookup
 
 
-def _is_path(source_string: object) -> bool:
-    """True if source tring is a path that starts with leading /"""
-    return isinstance(source_string, str) and source_string.startswith("/")
+def is_path(source: str | Path) -> bool:
+    """Returns true if source string is an absolute path (leading '/')"""
+    return str(source).startswith("/")
 
 
 def parse_diffoscope_output(
@@ -127,8 +124,8 @@ def parse_diffoscope_output(
     parent_source1: str = "",
     parent_source2: str = "",
     parent_comments: list[str] | None = None,
-    filetype_lookup1=None,
-    filetype_lookup2=None,
+    filetype_lookup1: dict[str, str] | None = None,
+    filetype_lookup2: dict[str, str] | None = None,
 ) -> tuple[int, int, int, list[dict[Any, Any]]]:
     """Recursively parses diffoscope json output
 
@@ -178,11 +175,11 @@ def parse_diffoscope_output(
         # Handles case where diff is found with a command such as stat {}.
         # Diffoscope lists the source of the diff as the command that it used to get
         # the diff, so the file path must be grabbed from the parent.
-        source1_raw = str(current_detail.get("source1", ""))
-        source2_raw = str(current_detail.get("source2", ""))
+        source1 = current_detail.get("source1", "")
+        source2 = current_detail.get("source2", "")
 
-        if not _is_path(source1_raw) or not _is_path(source2_raw):
-            diff.command = source1_raw
+        if not is_path(source1) or not is_path(source2):
+            diff.command = source1
             diff.source1 = parent_source1
             diff.source2 = parent_source2
 
@@ -226,13 +223,11 @@ def parse_diffoscope_output(
                             filetype_lookup1 is not None
                             and filetype_lookup2 is not None
                         ):
-                            rel1 = diff.source1
-                            rel2 = diff.source2
                             file_type_1 = (filetype_lookup1 or {}).get(
-                                rel1, ""
+                                diff.source1, ""
                             )
                             file_type_2 = (filetype_lookup2 or {}).get(
-                                rel2, ""
+                                diff.source2, ""
                             )
 
                             if file_type_1 and file_type_2:
@@ -242,6 +237,9 @@ def parse_diffoscope_output(
                                     file_type_2
                                 ):
                                     flag_matches = False
+                        else:
+                            # We want to keep the flag match as it is if no look up dict was passed
+                            pass
 
                 # Check if command matches flag
                 if flag_matches and not flag.regex["command"].search(

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -355,56 +355,11 @@ def parse_diffoscope_output(
                     current_detail["source1"],
                     current_detail["source2"],
                     current_detail.get("comments"),
-                    files_summary,
-                    file_checksum=file_checksum,
                 )
                 unknown_failures_count += child_return[0]
                 trivial_failures_count += child_return[1]
                 nontrivial_failures_count += child_return[2]
                 diff_list.extend(child_return[3])
-
-    checksum_summary = {}
-    # Only generate the final summary when it's top-level call (end of recursion)
-    if (
-        parent_source1 == ""
-        and parent_source2 == ""
-        and parent_comments is None
-    ):
-        # Path to rootfs of unpacked image, ex: image1/rootfs
-        rootfs_path1 = Path(current_detail["source1"])
-        rootfs_path2 = Path(current_detail["source2"])
-        hashed_files1 = hash_folder_contents(rootfs_path1)
-        hashed_files2 = hash_folder_contents(rootfs_path2)
-        diff_lookup = build_diff_lookup(diff_list)
-        checksum_summary = summarize_checksums(
-            diff_lookup,
-            rootfs_path1,
-            hashed_files1,
-            rootfs_path2,
-            hashed_files2,
-        )
-        trivial_diffs, nontrivial_diffs = classify_checksum_mismatches(
-            checksum_summary, diff_lookup, hashed_files1, hashed_files2
-        )
-        files_summary.append(
-            {
-                "image1": checksum_summary["image1"],
-                "image2": checksum_summary["image2"],
-                "only_in_image1": checksum_summary["only_in_image1"],
-                "only_in_image2": checksum_summary["only_in_image2"],
-                "trivial_checksum_different_files": trivial_diffs,
-                "nontrivial_checksum_different_files": nontrivial_diffs,
-            }
-        )
-        if file_checksum:
-            files_summary.append(
-                {
-                    "checksum_mismatches": checksum_summary[
-                        "checksum_mismatches"
-                    ],
-                    "checksum_matches": checksum_summary["checksum_matches"],
-                }
-            )
 
         return (
             unknown_failures_count,

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -367,7 +367,7 @@ def parse_diffoscope_output(
             nontrivial_failures_count,
             diff_list,
         )
-      
+
     return (
         unknown_failures_count,
         trivial_failures_count,

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -26,6 +26,7 @@
 """Utility Diffoscope functions."""
 
 import re
+from logging import getLogger
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +39,8 @@ from vessel.utils.unified_diff import (
     intervals_to_str,
     make_failure_dict,
 )
+
+logger = getLogger(__name__)
 
 
 def build_diffoscope_command(
@@ -113,12 +116,19 @@ def build_diff_lookup(
     return lookup
 
 
+def _is_path(source_string: object) -> bool:
+    """True if source tring is a path that starts with leading /"""
+    return isinstance(source_string, str) and source_string.startswith("/")
+
+
 def parse_diffoscope_output(
     current_detail: dict,
     flags: list[Flag],
     parent_source1: str = "",
     parent_source2: str = "",
     parent_comments: list[str] | None = None,
+    filetype_lookup1=None,
+    filetype_lookup2=None,
 ) -> tuple[int, int, int, list[dict[Any, Any]]]:
     """Recursively parses diffoscope json output
 
@@ -164,14 +174,15 @@ def parse_diffoscope_output(
             temp_comments,
             current_detail["unified_diff"],
         )
+
         # Handles case where diff is found with a command such as stat {}.
         # Diffoscope lists the source of the diff as the command that it used to get
         # the diff, so the file path must be grabbed from the parent.
-        if (
-            not Path(diff.source1).is_file()
-            and not Path(diff.source2).is_file()
-        ):
-            diff.command = current_detail["source1"]
+        src1_raw = str(current_detail.get("source1", ""))
+        src2_raw = str(current_detail.get("source2", ""))
+
+        if not _is_path(src1_raw) or not _is_path(src2_raw):
+            diff.command = src1_raw
             diff.source1 = parent_source1
             diff.source2 = parent_source2
 
@@ -197,23 +208,40 @@ def parse_diffoscope_output(
                 ):
                     flag_matches = False
 
-                # Check if filetype matches flag
-                if (
-                    flag_matches
-                    and Path(diff.source1).is_file()
-                    and Path(diff.source2).is_file()
-                ):
-                    file_type_1 = magic.from_file(
-                        diff.source1,
-                    )
-                    file_type_2 = magic.from_file(
-                        diff.source2,
-                    )
+                #  - If both files exist locally, use magic library for data type.
+                #  - Else, use types from the metadata.
+                if flag_matches:
+                    source_1_exists = Path(diff.source1).is_file()
+                    source_2_exists = Path(diff.source2).is_file()
+                    if source_1_exists and source_2_exists:
+                        file_type_1 = magic.from_file(diff.source1)
+                        file_type_2 = magic.from_file(diff.source2)
+                        if not flag.regex["filetype"].search(
+                            file_type_1
+                        ) or not flag.regex["filetype"].search(file_type_2):
+                            flag_matches = False
+                    else:
+                        # Local file does not exist: try checksum metadata lookups.
+                        if (
+                            filetype_lookup1 is not None
+                            and filetype_lookup2 is not None
+                        ):
+                            rel1 = diff.source1
+                            rel2 = diff.source2
+                            file_type_1 = (filetype_lookup1 or {}).get(
+                                rel1, ""
+                            )
+                            file_type_2 = (filetype_lookup2 or {}).get(
+                                rel2, ""
+                            )
 
-                    if not flag.regex["filetype"].search(
-                        file_type_1,
-                    ) or not flag.regex["filetype"].search(file_type_2):
-                        flag_matches = False
+                            if file_type_1 and file_type_2:
+                                if not flag.regex["filetype"].search(
+                                    file_type_1
+                                ) or not flag.regex["filetype"].search(
+                                    file_type_2
+                                ):
+                                    flag_matches = False
 
                 # Check if command matches flag
                 if flag_matches and not flag.regex["command"].search(
@@ -355,6 +383,8 @@ def parse_diffoscope_output(
                     current_detail["source1"],
                     current_detail["source2"],
                     current_detail.get("comments"),
+                    filetype_lookup1=filetype_lookup1,
+                    filetype_lookup2=filetype_lookup2,
                 )
                 unknown_failures_count += child_return[0]
                 trivial_failures_count += child_return[1]


### PR DESCRIPTION
- Enabled diff with checksum metadata and diffoscope output directly
- Stripped out checksum summary logic from parse_diffoscope_output into generate_filesummary_and_checksum
- Refactor the analysis steps in diffoscope_command
- Removed file checksum boolean flag since we are always storing checksum info in metadata file
- Added unit test for new generate_filesummary_and_checksum function

Command for testing: 
`docker run --rm -v /srv/local/lzhan/new_effectiveness/metadata/output_2:/input/output_2 -v ./output:/output -v ./vessel:/opt/project/vessel vessel diff /input/output_2/checksum_metadata.json /input/output_2/diffoscope_output.json -o /output`
