### PR TITLE
Remove All tmp diffoscope, Make Profile Output Optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && \
     skopeo=1.9.3+ds1-1+b10 \
     umoci=0.4.7+ds-3+b7 \
     libmagic-dev=1:5.44-3 \
-    libarchive-dev=3.6.2-1+deb12u2 \
-    libarchive-tools=3.6.2-1+deb12u2 \
-    sudo=1.9.13p3-1+deb12u1 \
+    libarchive-dev=3.6.2-1+deb12u3 \
+    libarchive-tools=3.6.2-1+deb12u3 \
+    sudo-ldap=1.9.13p3-1+deb12u2 \
     p7zip-full=16.02+dfsg-8 \
     r-base=4.2.2.20221110-2 \
     abootimg=0.6-1+b2 \
@@ -31,7 +31,7 @@ RUN apt-get update && \
     coreboot-utils=4.15~dfsg-3 \
     default-jdk-headless=2:1.17-74 \
     device-tree-compiler=1.6.1-4+b1 \
-    ffmpeg=7:5.1.6-0+deb12u1 \
+    ffmpeg=7:5.1.7-0+deb12u1 \
     fontforge-extras=1:20230101~dfsg-1.1~deb12u1 \
     fp-utils=3.2.2+dfsg-20 \
     genisoimage=9:1.1.11-3.4 \
@@ -45,7 +45,7 @@ RUN apt-get update && \
     llvm=1:14.0-55.7~deb12u1 \
     lz4=1.9.4-1 \
     lzip=1.23-5 \
-    mono-utils=6.8.0.105+dfsg-3.3 \
+    mono-utils=6.8.0.105+dfsg-3.3+deb12u1 \
     ocaml-nox=4.13.1-4 \
     odt2txt=0.5-7 \
     oggvideotools=0.9.1-6 \
@@ -54,14 +54,14 @@ RUN apt-get update && \
     procyon-decompiler=0.6.0-1 \
     python3-pdfminer=20221105+dfsg-1 \
     sng=1.1.0-4 \
-    sqlite3=3.40.1-2+deb12u1 \
+    sqlite3=3.40.1-2+deb12u2 \
     u-boot-tools=2023.01+dfsg-2+deb12u1 \
     tcpdump=4.99.3-1 \
     wabt=1.0.32-1 \
     xmlbeans=4.0.0-2 \
     xxd=2:9.0.1378-2+deb12u2 \
     python3-guestfs=1:1.48.6-2  \
-    ca-certificates=20230311 \
+    ca-certificates=20230311+deb12u1 \
     pipx=1.1.0-1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/test/util/test_diffoscope.py
+++ b/test/util/test_diffoscope.py
@@ -41,7 +41,7 @@ def test_build_diffoscope_command():
     path1 = "/test_path/file1"
     path2 = "/test_path/file2"
 
-    def make_expected(profile_enabled: bool) -> list[str]:
+    def make_expected_output(profile_enabled):
         expected = [
             "diffoscope",
             "--json",
@@ -71,12 +71,12 @@ def test_build_diffoscope_command():
     # without profile
     assert build_diffoscope_command(
         output_dir, output_file, path1, path2, "file", profile_enabled=False
-    ) == make_expected(False)
+    ) == make_expected_output(False)
 
     # with profile
     assert build_diffoscope_command(
         output_dir, output_file, path1, path2, "file", profile_enabled=True
-    ) == make_expected(True)
+    ) == make_expected_output(True)
 
 
 @pytest.mark.parametrize(

--- a/test/util/test_diffoscope.py
+++ b/test/util/test_diffoscope.py
@@ -35,61 +35,48 @@ from vessel.utils.diffoscope import (
 )
 
 
-def test_build_diffoscope_command_file_mode() -> None:
+def test_build_diffoscope_command():
     output_dir = "/tmp"
     output_file = "diff.json"
     path1 = "/test_path/file1"
     path2 = "/test_path/file2"
 
+    def make_expected(profile_enabled: bool) -> list[str]:
+        expected = [
+            "diffoscope",
+            "--json",
+            f"{output_dir}/{output_file}",
+            "--new-file",
+            path1,
+            path2,
+            "--exclude-directory-metadata",
+            "no",
+        ]
+        if profile_enabled:
+            expected.extend(["--profile", f"{output_dir}/profile.txt"])
+        expected.extend(
+            [
+                "--exclude-command",
+                r"^readelf.*",
+                "--exclude-command",
+                r"^objdump.*",
+                "--exclude-command",
+                r"^strings.*",
+                "--exclude-command",
+                r"^xxd.*",
+            ]
+        )
+        return expected
+
     # without profile
-    expected_no_profile = [
-        "diffoscope",
-        "--json",
-        f"{output_dir}/{output_file}",
-        "--new-file",
-        path1,
-        path2,
-        "--exclude-directory-metadata",
-        "no",
-        "--exclude-command",
-        r"^readelf.*",
-        "--exclude-command",
-        r"^objdump.*",
-        "--exclude-command",
-        r"^strings.*",
-        "--exclude-command",
-        r"^xxd.*",
-    ]
-    actual_no_profile = build_diffoscope_command(
+    assert build_diffoscope_command(
         output_dir, output_file, path1, path2, "file", profile_enabled=False
-    )
-    assert actual_no_profile == expected_no_profile
+    ) == make_expected(False)
 
     # with profile
-    expected_with_profile = [
-        "diffoscope",
-        "--json",
-        f"{output_dir}/{output_file}",
-        "--new-file",
-        path1,
-        path2,
-        "--exclude-directory-metadata",
-        "no",
-        "--profile",
-        f"{output_dir}/profile.txt",
-        "--exclude-command",
-        r"^readelf.*",
-        "--exclude-command",
-        r"^objdump.*",
-        "--exclude-command",
-        r"^strings.*",
-        "--exclude-command",
-        r"^xxd.*",
-    ]
-    actual_with_profile = build_diffoscope_command(
+    assert build_diffoscope_command(
         output_dir, output_file, path1, path2, "file", profile_enabled=True
-    )
-    assert actual_with_profile == expected_with_profile
+    ) == make_expected(True)
 
 
 @pytest.mark.parametrize(

--- a/test/util/test_diffoscope.py
+++ b/test/util/test_diffoscope.py
@@ -35,12 +35,44 @@ from vessel.utils.diffoscope import (
 )
 
 
-def test_build_diffoscope_command():
+def test_build_diffoscope_command_file_mode() -> None:
     output_dir = "/tmp"
     output_file = "diff.json"
     path1 = "/test_path/file1"
     path2 = "/test_path/file2"
-    exclude_params = [
+
+    # without profile
+    expected_no_profile = [
+        "diffoscope",
+        "--json",
+        f"{output_dir}/{output_file}",
+        "--new-file",
+        path1,
+        path2,
+        "--exclude-directory-metadata",
+        "no",
+        "--exclude-command",
+        r"^readelf.*",
+        "--exclude-command",
+        r"^objdump.*",
+        "--exclude-command",
+        r"^strings.*",
+        "--exclude-command",
+        r"^xxd.*",
+    ]
+    actual_no_profile = build_diffoscope_command(
+        output_dir, output_file, path1, path2, "file", profile_enabled=False
+    )
+    assert actual_no_profile == expected_no_profile
+
+    # with profile
+    expected_with_profile = [
+        "diffoscope",
+        "--json",
+        f"{output_dir}/{output_file}",
+        "--new-file",
+        path1,
+        path2,
         "--exclude-directory-metadata",
         "no",
         "--profile",
@@ -54,35 +86,10 @@ def test_build_diffoscope_command():
         "--exclude-command",
         r"^xxd.*",
     ]
-
-    expected_cmd_file = [
-        "diffoscope",
-        "--json",
-        "/tmp/diff.json",
-        "--new-file",
-        path1,
-        path2,
-    ]
-    expected_cmd_file.extend(exclude_params)
-    assert (
-        build_diffoscope_command(output_dir, output_file, path1, path2, "file")
-        == expected_cmd_file
+    actual_with_profile = build_diffoscope_command(
+        output_dir, output_file, path1, path2, "file", profile_enabled=True
     )
-
-    expected_cmd_image = [
-        "diffoscope",
-        "--json",
-        f"{output_dir}/{output_file}",
-        path1,
-        path2,
-    ]
-    expected_cmd_image.extend(exclude_params)
-    assert (
-        build_diffoscope_command(
-            output_dir, output_file, path1, path2, "image"
-        )
-        == expected_cmd_image
-    )
+    assert actual_with_profile == expected_with_profile
 
 
 @pytest.mark.parametrize(

--- a/vessel/cli.py
+++ b/vessel/cli.py
@@ -99,11 +99,22 @@ def vessel(logging_level: str) -> None:
         "'json' for diffoscope/checksum JSON comparison."
     ),
 )
+@click.option(
+    "-p",
+    "--profile",
+    default=False,
+    show_default=True,
+    help=(
+        "When enabled, pass '--profile <output-dir>/profile.txt' to diffoscope "
+        "to record timing stats."
+    ),
+)
 def diff(
     input_files: list[str],
     data_dir: str,
     mode: str,
     output_dir: str,
+    profile: bool,
 ) -> None:
     """Unpack container images and compare differences with diffoscope.
 
@@ -114,5 +125,6 @@ def diff(
         data_dir,
         mode,
         output_dir,
+        profile,
     ).execute()
     sys.exit(not success)

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -67,6 +67,7 @@ class DiffCommand:
         data_dir: str,
         mode: str,
         output_dir: str,
+        profile: bool,
     ) -> None:
         """Initializer for a diff operation.
 
@@ -81,6 +82,7 @@ class DiffCommand:
         self.image_uris: list[ImageURI] = []
         self.oci_image_paths: list[str] = []
         self.oci_runtime_paths: list[str] = []
+        self.profile_enabled: bool = profile
 
     def execute(self: "DiffCommand") -> bool:
         """Executes a diff operation.
@@ -217,6 +219,7 @@ class DiffCommand:
             self.oci_image_paths[0],
             self.oci_image_paths[1],
             self.mode,
+            self.profile_enabled,
         )
         try:
             subprocess.run(cmd, check=True)  # noqa: S603
@@ -284,6 +287,7 @@ class DiffCommand:
             f"{self.oci_runtime_paths[0]}/rootfs",
             f"{self.oci_runtime_paths[1]}/rootfs",
             self.mode,
+            self.profile_enabled,
         )
         try:
             subprocess.run(cmd, check=True)  # noqa: S603

--- a/vessel/diff/diff_command.py
+++ b/vessel/diff/diff_command.py
@@ -67,7 +67,7 @@ class DiffCommand:
         data_dir: str,
         mode: str,
         output_dir: str,
-        profile: bool,
+        profile_enabled: bool,
     ) -> None:
         """Initializer for a diff operation.
 
@@ -82,7 +82,7 @@ class DiffCommand:
         self.image_uris: list[ImageURI] = []
         self.oci_image_paths: list[str] = []
         self.oci_runtime_paths: list[str] = []
-        self.profile_enabled: bool = profile
+        self.profile_enabled: bool = profile_enabled
 
     def execute(self: "DiffCommand") -> bool:
         """Executes a diff operation.

--- a/vessel/utils/diffoscope.py
+++ b/vessel/utils/diffoscope.py
@@ -46,6 +46,7 @@ def build_diffoscope_command(
     path1: str,
     path2: str,
     mode: str,
+    profile_enabled: bool,
 ) -> list[str]:
     """Generates a command list to execute diffoscope.
 
@@ -56,6 +57,7 @@ def build_diffoscope_command(
         path1: The first path to compare
         path2: The second path to compare
         mode: Comparison mode ("image" or "file")
+        profile_enabled: If True, append '--profile <output_dir_path>/profile.txt'
 
     Returns:
         Commands list to execute diffoscope.
@@ -68,7 +70,8 @@ def build_diffoscope_command(
 
     cmd.extend([path1, path2])
     cmd.extend(["--exclude-directory-metadata", "no"])
-    cmd.extend(["--profile", f"{output_dir_path}/profile.txt"])
+    if profile_enabled:
+        cmd.extend(["--profile", f"{output_dir_path}/profile.txt"])
     exclude_patterns = [
         r"^readelf.*",
         r"^objdump.*",
@@ -372,8 +375,10 @@ def parse_diffoscope_output(
             if (
                 child["source1"][0] != "/"
                 or child["source2"][0] != "/"
-                or umociRegex.search(child["source1"])
-                or umociRegex.search(child["source2"])
+                or (
+                    umociRegex.search(child["source1"])
+                    and umociRegex.search(child["source2"])
+                )
             ):
                 child_return = parse_diffoscope_output(
                     child,


### PR DESCRIPTION
* Make sure if any of source1 or source2 has tmp diffoscope path, they are removed
* Added flag to toggle Profile on and off, off by default
* Refactored unit test to match with updated function